### PR TITLE
Add: 로그아웃 실행 여부 확인용 리스너, 로그아웃 버튼 공통 이벤트리스너 추가

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/config/LogoutListener.java
+++ b/src/main/java/com/example/KeyboardArenaProject/config/LogoutListener.java
@@ -1,0 +1,29 @@
+package com.example.KeyboardArenaProject.config;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.LogoutSuccessEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class LogoutListener implements ApplicationListener<LogoutSuccessEvent> {
+	@Override
+	public void onApplicationEvent(LogoutSuccessEvent event) {
+		log.info("LogoutListener : 로그아웃 이벤트 발생");
+
+		// 현재 인증된 사용자 정보 조회
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication != null) {
+			String username = authentication.getName();
+			log.info("LogoutListener :로그아웃 전 로그인된 사용자: {}", username);
+		} else {
+			log.info("LogoutListener :로그인된 사용자가 없습니다.");
+		}
+	}
+
+}

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
@@ -42,7 +42,6 @@ public class UserController {
 
 	@GetMapping("/logout")
 	public String logout(HttpServletRequest request, HttpServletResponse response) {
-		log.info("userController - logout : 로그아웃");
 		new SecurityContextLogoutHandler().logout(request, response,
 			SecurityContextHolder.getContext().getAuthentication());
 		return "redirect:/login";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ spring.jpa.defer-datasource-initialization=true
 
 spring.mvc.hiddenmethod.filter.enabled=true
 
-#?? smtp ??
+# mail smtp configuration
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=team.keyboard.arena@gmail.com

--- a/src/main/resources/static/js/LogoutBtn.js
+++ b/src/main/resources/static/js/LogoutBtn.js
@@ -1,0 +1,15 @@
+const logoutBtn = document.getElementById("logoutButton");
+logoutBtn.addEventListener('click', (e) => {
+    fetch('/logout', {
+        method: 'GET',
+    })
+        .then(response => {
+            console.log(response);
+            if (response.redirected) {
+                window.location.href = response.url; // Redirect to login page
+            }
+        })
+        .catch(error => {
+            console.error('Error logging out:', error);
+        });
+})

--- a/src/main/resources/templates/freeboardDetail.html
+++ b/src/main/resources/templates/freeboardDetail.html
@@ -7,11 +7,12 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title th:text="${post.title}"></title>
     <script defer src="/js/FreeBoard.js"></script>
+    <script defer src="/js/LogoutBtn.js"></script>
 </head>
 <body>
 <header>
     <h1>Keyboard Arena</h1>
-    <button type="button" class="btn btn-secondary" onclick="location.href='/logout'">로그아웃</button>
+    <button type="button" id="logoutButton">로그아웃</button>
 </header>
 <main>
     <h2 th:text="${post.title}"></h2>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -6,11 +6,12 @@
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>자유게시판</title>
+    <script defer src="/js/LogoutBtn.js"></script>
 </head>
 <body>
 <header>
     <h1>Keyboard Arena</h1>
-    <button type="button" class="btn btn-secondary" onclick="location.href='/logout'">로그아웃</button>
+    <button type="button" id="logoutButton">로그아웃</button>
 </header>
 <main>
     <button th:onclick="|location.href='@{/newFreeboard}'|">게시판 글 쓰기</button>

--- a/src/main/resources/templates/newFreeboard.html
+++ b/src/main/resources/templates/newFreeboard.html
@@ -6,6 +6,7 @@
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>자유게시판 글 쓰기</title>
+    <script defer src="/js/LogoutBtn.js"></script>
 </head>
 <body>
 <header>
@@ -14,7 +15,7 @@
         <li th:text="${user.nickname}"></li>
         <li th:text="${user.userRank}"></li>
         <li th:text="${user.point}"></li>
-        <li><button type="button"  onclick="location.href='/logout'">로그아웃</button></li>
+        <li><button type="button" id="logoutButton">로그아웃</button></li>
     </ul>
 </header>
 <main>

--- a/src/main/resources/templates/updateFreeboard.html
+++ b/src/main/resources/templates/updateFreeboard.html
@@ -6,6 +6,7 @@
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>자유게시판 수정하기</title>
+    <script defer src="/js/LogoutBtn.js"></script>
 </head>
 <body>
 <header>
@@ -14,7 +15,7 @@
         <li th:text="${user.nickname}"></li>
         <li th:text="${user.userRank}"></li>
         <li th:text="${user.point}"></li>
-        <li><button type="button"  onclick="location.href='/logout'">로그아웃</button></li>
+        <li><button type="button" id="logoutButton">로그아웃</button></li>
     </ul>
 </header>
 <main>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #1 

## 📝 구현 사항
<!-- 과제에 대한 설명을 적어주세요 -->
- ✔로그아웃 api url: `GET ~/logout` 

1. 로그아웃 실행 여부를 확인하기 위한 리스너 추가
- 기존 코드에서 로그아웃 버튼을 누를 경우, /login 페이지로 리다이렉션 되는 것은 정상적으로 확인되었으나, 
컨트롤러의 `login` 메소드 단에서 `log.info(), log.debug` 등으로 로그를 확인하려 해도 로그가 출력되지 않다 보니 실제로 유저가 로그아웃이 잘 되었는지(인증정보가 더이상 조회되지 않는지) 확인할 수 없었습니다.
```java
	@GetMapping("/logout") // 이 단에서 로깅/인증정보 확인 등 추가 작업 불가
	public String logout(HttpServletRequest request, HttpServletResponse response) {
		new SecurityContextLogoutHandler().logout(request, response,
			SecurityContextHolder.getContext().getAuthentication());
		return "redirect:/login"; 
	}
```

- ❓ 컨트롤러단에서 로깅이 어려웠던 이유
  - 스프링 시큐리티의 로그아웃 기능을 사용할 경우, 로그아웃 요청이 들어오면 `SecurityContextLogoutHandler`가 자동으로 현재 사용자를 로그아웃 처리하고 세션을 무효화합니다. 이 과정에서 사용자가 로그아웃되었으므로 이후의 코드 실행이 중지됩니다. 따라서 로그아웃 요청을 처리하는 컨트롤러의 메소드가 호출된 후에는 해당 메소드 내에서 추가적인 로그 출력이나 작업이 실행되지 않을 수 있습니다.
  - 따라서 스프링 시큐리티의 로그아웃 기능을 사용할 때는 로그아웃 후의 작업이 필요한 경우 스프링 시큐리티의 이벤트 기능을 사용하여 로그아웃 후에 추가적인 작업을 수행할 수 있다고 합니다.
  - 이를 위해 `ApplicationListener`나 `@EventListener` 어노테이션을 사용하는데, 저의 경우 `ApplicationListener`를 구현하는 `LogoutListener`를 생성했습니다.

2. 로그아웃 버튼 javascript 이벤트 리스너 등록
- index.html, newFreeboard.html, updateFreeboard.html 에서 로그아웃버튼이 공통적으로 사용되고 있기 때문에 버튼 이벤트 리스너를 html마다 공통적으로 적용해뒀습니다

## TODO
- [ ] 