### PR TITLE
Feat: 비밀번호 찾기(초기화) api 구현 및 뷰 연동 (pr 작성중 ..)

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/KeyboardArenaProject/config/WebSecurityConfig.java
@@ -21,7 +21,7 @@ public class WebSecurityConfig {
 	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
 		httpSecurity.authorizeHttpRequests(auth ->
 				auth.requestMatchers(
-					"/login", "/signup", "/user", "/findId", "/findPw", "/user/find/id","/user/find/email")
+					"/login", "/signup", "/user", "/findId", "/findPw", "/user/find/id","/user/find/email", "/user/find/pw")
 					.permitAll()
 					.anyRequest()
 					.authenticated())

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.example.KeyboardArenaProject.dto.user.AddUserRequest;
+import com.example.KeyboardArenaProject.dto.user.ResetPwRequest;
 import com.example.KeyboardArenaProject.dto.user.UserResponse;
 import com.example.KeyboardArenaProject.entity.User;
 import com.example.KeyboardArenaProject.service.user.UserService;
@@ -74,6 +75,21 @@ public class UserController {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to send user ID");
 		}
 	}
+
+	@PostMapping("/user/find/pw")
+	public ResponseEntity<String> resetPassword(@RequestBody ResetPwRequest resetPwRequest) {
+		try {
+			String newPassword = userService.resetPassword(resetPwRequest.getUserId(),
+				resetPwRequest.getFindPwQuestion(), resetPwRequest.getFindPw());
+			return ResponseEntity.status(HttpStatus.OK).body(newPassword);
+		} catch(UserNotFoundException e) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("회원정보를 조회할 수 없습니다.");
+		} catch(Exception e) {
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("비밀번호 찾기 중 오류가 발생했습니다.");
+		}
+
+	}
+
 
 	// 테스트 용도
 	@GetMapping("/userinfo")

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
@@ -78,9 +78,13 @@ public class UserController {
 
 	@PostMapping("/user/find/pw")
 	public ResponseEntity<String> resetPassword(@RequestBody ResetPwRequest resetPwRequest) {
+		log.info("UserController - resetPassword: {}, {}, {}", resetPwRequest.getUserId(),
+			resetPwRequest.getFindPwQuestion(),
+			resetPwRequest.getFindPw());
 		try {
 			String newPassword = userService.resetPassword(resetPwRequest.getUserId(),
 				resetPwRequest.getFindPwQuestion(), resetPwRequest.getFindPw());
+			log.info("newPassword: {}", newPassword);
 			return ResponseEntity.status(HttpStatus.OK).body(newPassword);
 		} catch(UserNotFoundException e) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("회원정보를 조회할 수 없습니다.");

--- a/src/main/java/com/example/KeyboardArenaProject/dto/user/ResetPwRequest.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/user/ResetPwRequest.java
@@ -1,0 +1,10 @@
+package com.example.KeyboardArenaProject.dto.user;
+
+import lombok.Data;
+
+@Data
+public class ResetPwRequest {
+	private String userId;
+	private String findPwQuestion;
+	private String findPw;
+}

--- a/src/main/java/com/example/KeyboardArenaProject/repository/UserRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, String> {
 	Optional<User> findByEmail(String email);
 	boolean existsByUserId(String userId);
 	boolean existsByEmail(String email);
+	Optional<User> findByUserIdAndFindPwQuestionAndFindPw(String userId, String findPwQuestion, String findPw);
 }

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/UserService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/UserService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import com.example.KeyboardArenaProject.dto.user.AddUserRequest;
 import com.example.KeyboardArenaProject.entity.User;
 import com.example.KeyboardArenaProject.repository.UserRepository;
+import com.example.KeyboardArenaProject.utils.GeneratePwUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -90,6 +91,21 @@ public class UserService {
 		return userRepository.existsByEmail(email);
 	}
 
+	public String resetPassword(String userId, String question, String answer) {
+		Optional<User> userOptional = userRepository.findByUserIdAndFindPwQuestionAndFindPw(userId, question, answer);
+		if(userOptional.isPresent()) {
+			User user = userOptional.get();
+			log.info("service - resetPassword 찾은 userId: {}", user.getUserId());
+			String newPassword = GeneratePwUtils.generateNewPassword();
+
+			String encryptedPassword = encoder.encode(newPassword);
+			user.setPassword(encryptedPassword);
+			userRepository.save(user);
+			return newPassword;
+		} else {
+			throw new UserNotFoundException("User not found with userId:" + userId + ", question: " + question + ", answer: " + answer);
+		}
+	}
 
 	//임시 유저 닉네임 제공 함수
 	public String getNickNameById(String id){
@@ -114,6 +130,12 @@ public class UserService {
 			super(message);
 		}
 	}
+
+	// public class InCorrectAnswerException extends RuntimeException {
+	// 	public InCorrectAnswerException(String message) {
+	// 		super(message);
+	// 	}
+	// }
 }
 
 

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/UserService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/UserService.java
@@ -99,10 +99,13 @@ public class UserService {
 			String newPassword = GeneratePwUtils.generateNewPassword();
 
 			String encryptedPassword = encoder.encode(newPassword);
+			log.info("userService - encryptedPassword: {}", encryptedPassword);
 			user.setPassword(encryptedPassword);
 			userRepository.save(user);
+			log.info("userService - user's new password: {}", user.getPassword());
 			return newPassword;
 		} else {
+			log.info("service - resetPassword : UserNotFoundException");
 			throw new UserNotFoundException("User not found with userId:" + userId + ", question: " + question + ", answer: " + answer);
 		}
 	}

--- a/src/main/java/com/example/KeyboardArenaProject/utils/GeneratePwUtils.java
+++ b/src/main/java/com/example/KeyboardArenaProject/utils/GeneratePwUtils.java
@@ -1,0 +1,9 @@
+package com.example.KeyboardArenaProject.utils;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class GeneratePwUtils {
+	public static String generateNewPassword() {
+		return RandomStringUtils.randomAlphanumeric(10);
+	}
+}

--- a/src/main/resources/static/js/FindPw.js
+++ b/src/main/resources/static/js/FindPw.js
@@ -15,7 +15,7 @@ document.getElementById('findPwForm').addEventListener('submit', function (event
     var formData = {
         userId: document.getElementById('userId').value,
         findPwQuestion: select,
-        findPw: document.getElementById('findPwAnswer').value,
+        findPw: document.getElementById('findPwAnswer').value.trim(),
     };
 
     console.log(formData.userId);

--- a/src/main/resources/static/js/FindPw.js
+++ b/src/main/resources/static/js/FindPw.js
@@ -1,0 +1,49 @@
+document.getElementById('findPwForm').addEventListener('submit', function (event) {
+    event.preventDefault();
+    var select = document.getElementById("findPwQuestion").value;
+    switch (select) {
+        case "place":
+            select = "기억에 남는 추억의 장소는?";
+            break;
+        case "treasure":
+            select = "자신의 보물 제1호는?";
+            break;
+        case "elementary":
+            select = "자신의 출신 초등학교는?";
+            break;
+    }
+    var formData = {
+        userId: document.getElementById('userId').value,
+        findPwQuestion: select,
+        findPw: document.getElementById('findPwAnswer').value,
+    };
+
+    console.log(formData.userId);
+    console.log(formData.findPwQuestion);
+    console.log(formData.findPw);
+
+    fetch('/user/find/pw', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            alert("회원정보가 일치합니다");
+            return response.text(); // JSON 형식이 아닌 경우 text로 반환
+        })
+        .then(data => {
+            console.log("data: ", data);
+            // 서버로부터 받은 초기화된 비밀번호를 화면에 출력
+            var resetPwResultDiv = document.getElementById('resetPwResult');
+            resetPwResultDiv.innerHTML = "<p>비밀번호가 초기화되었습니다<br>초기화된 비밀번호: " + data + "</p>";
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            alert('비밀번호 초기화에 실패했습니다.');
+        });
+});

--- a/src/main/resources/static/js/Signup.js
+++ b/src/main/resources/static/js/Signup.js
@@ -68,12 +68,25 @@ duplicateEmailCheckButton.addEventListener("click", async () => {
     }
 });
 function signup() {
+    var select = document.getElementById("findPwQuestion").value;
+    switch (select) {
+        case "place":
+            select = "기억에 남는 추억의 장소는?";
+            break;
+        case "treasure":
+            select = "자신의 보물 제1호는?";
+            break;
+        case "elementary":
+            select = "자신의 출신 초등학교는?";
+            break;
+    }
+    console.log("select: ", select);
     var formData = {
         userId: document.getElementById("userId").value,
         password: document.getElementById("password").value,
         nickname: document.getElementById("nickname").value,
         email: document.getElementById("email").value,
-        findPwQuestion: document.getElementById("findPwQuestion").value,
+        findPwQuestion: select,
         findPw: document.getElementById("findPw").value
     };
 

--- a/src/main/resources/templates/findPw.html
+++ b/src/main/resources/templates/findPw.html
@@ -26,10 +26,6 @@
             <input id="findPwAnswer" name="findPwAnswer" required>
             <button id="resetPwButton" type="submit">확인</button>
         </form>
-<!--        <div id="loading">-->
-<!--            아이디를 찾는 중입니다.<br>-->
-<!--            <img id="loading-img" alt="loading" src="/media/loading.gif">-->
-<!--        </div>-->
         <div id="resetPwResult"></div>
     </div>
 </main>

--- a/src/main/resources/templates/findPw.html
+++ b/src/main/resources/templates/findPw.html
@@ -3,8 +3,35 @@
 <head>
     <meta charset="UTF-8">
     <title>Keyboard Arena</title>
+    <script defer src="/js/FindPw.js"></script>
 </head>
 <body>
-findPw
+<header>
+    <h1>Keyboard Arena</h1>
+</header>
+<main>
+    <div>
+        <h2>비밀번호 찾기</h2>
+        <form id="findPwForm">
+            회원 아이디와 함께 회원가입시 등록한 질문과 답변을 입력하세요. 입력한 정보가 일치할 경우 비밀번호를 초기화합니다.<br><br>
+            <label for="userId">아이디</label><br><br>
+            <input id="userId" name="userId" required><br><br>
+            <label for="findPwQuestion">비밀번호 확인 질문</label><br><br>
+            <select name="questions" id="findPwQuestion" required>
+                <option value="place">기억에 남는 추억의 장소는?</option>
+                <option value="treasure">자신의 보물 제1호는?</option>
+                <option value="elementary">자신의 출신 초등학교는?</option>
+            </select><br><br>
+            <label for="findPwAnswer">비밀번호 확인 답변</label><br><br>
+            <input id="findPwAnswer" name="findPwAnswer" required>
+            <button id="resetPwButton" type="submit">확인</button>
+        </form>
+<!--        <div id="loading">-->
+<!--            아이디를 찾는 중입니다.<br>-->
+<!--            <img id="loading-img" alt="loading" src="/media/loading.gif">-->
+<!--        </div>-->
+        <div id="resetPwResult"></div>
+    </div>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -22,7 +22,6 @@
         <option value="treasure">자신의 보물 제1호는?</option>
         <option value="elementary">자신의 출신 초등학교는?</option>
     </select><br><br>
-<!--    <input type="text" id="findPwQuestion" name="findPwQuestion" required><br><br>-->
 
     <label for="findPw">비밀번호 확인 답</label>
     <input type="text" id="findPw" name="findPw" required><br><br>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -17,7 +17,12 @@
     <input type="password" id="password" name="password" required><br><br>
 
     <label for="findPwQuestion">비밀번호 확인 질문</label>
-    <input type="text" id="findPwQuestion" name="findPwQuestion" required><br><br>
+    <select name="questions" id="findPwQuestion" required>
+        <option value="place">기억에 남는 추억의 장소는?</option>
+        <option value="treasure">자신의 보물 제1호는?</option>
+        <option value="elementary">자신의 출신 초등학교는?</option>
+    </select><br><br>
+<!--    <input type="text" id="findPwQuestion" name="findPwQuestion" required><br><br>-->
 
     <label for="findPw">비밀번호 확인 답</label>
     <input type="text" id="findPw" name="findPw" required><br><br>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #1 

## 📝 구현 사항
<!-- 과제에 대한 설명을 적어주세요 -->
- ✔ 화면: `findPw.html`
- ✔ 비밀번호 찾기(초기화) api url: `POST ~/user/find/pw` 
- ✔ 이메일 중복체크 api url: `GET ~/user/find/email` 

- 회원가입 UI에서 드롭다운을 통해 비밀번호 찾기 질문을 설정할 수 있도록 합니다.
- 비밀번호를 분실한 유저가 아이디, 비밀번호 확인 질문, 비밀번호 확인 답을 입력하면 비밀번호를 초기화하는 api를 구현하고 html 뷰와 연동합니다.
- 비밀번호 초기화 로직
  1. 아이디, 비밀번호 확인 질문, 비밀번호 확인 답이 모두 일치하는 유저 정보를 조회합니다.
  2. `RandomStringUtils.randomAlphanumeric(10);`를 사용해 랜덤한 알파벳+숫자 조합의 10자리 문자열을생성합니다.
  3. `BCryptPasswordEncoder`를 통해 해당 문자열을 암호화합니다.
  4. 조회된 유저의 비밀번호를 암호화된 새로운 문자열로 대체합니다.
  
## 캡쳐본
🔽 회원가입 ui에 질문 관련 드롭다운 추가
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/8056e8fc-7bdd-42a3-ab51-c6a1fa1b97e1" width="40%">

🔽 비밀번호 찾기 첫 화면
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/93987327-bcfd-4f79-9a5f-f03e49f32e5b" width="70%">

🔽 입력한 아이디, 비밀번호 확인 질문, 비밀번호 확인 답변이 모두 일치하는 유저정보가 조회되면 alert 출력
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/172c3f3d-0169-496e-bd75-79c2a40a3431" width="70%">

🔽alert를 닫은 후 초기화된 비밀번호가 화면에 출력됩니다
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/a65a8779-228c-4a0e-9fa2-28d9fb21a191" width="70%">


## TODO
- [ ] (여유되면) api 예외처리 세분화
- [ ] 비밀번호 찾기 UI 세부수정