### PR TITLE
Feat: 회원가입 모든 필드 필수 입력 validation 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.4'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
@@ -6,7 +6,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -33,7 +37,12 @@ public class UserController {
 	}
 
 	@PostMapping("/user")
-	public ResponseEntity<UserResponse> signup(@RequestBody AddUserRequest request) {
+	public ResponseEntity<?> signup(@Validated @RequestBody AddUserRequest request, BindingResult bindingResult) {
+		if (bindingResult.hasErrors()) {
+			// 바인딩 오류가 발생한 경우, 오류 메시지를 클라이언트로 반환
+			log.info("errors = \n{}", bindingResult);
+			return ResponseEntity.badRequest().body(bindingResult.getAllErrors());
+		}
 		User user = userService.save(request);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(user.toResponse());

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/UserViewController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/UserViewController.java
@@ -3,7 +3,6 @@ package com.example.KeyboardArenaProject.controller.user;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-
 import com.example.KeyboardArenaProject.service.user.UserService;
 
 @Controller

--- a/src/main/java/com/example/KeyboardArenaProject/dto/user/AddUserRequest.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/user/AddUserRequest.java
@@ -1,12 +1,28 @@
 package com.example.KeyboardArenaProject.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
-@Data
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class AddUserRequest {
-	private String userId;
-	private String password;
-	private String nickname;
+	@NotBlank(message = "userId is mandatory")
+	private String userId; // 아이디 (6~12자 이내, 영문/숫자 사용가능)
+
+	@NotBlank(message = "password is mandatory")
+	private String password; //비밀번호(8~16자 이내, 영문/숫자/기호 사용가능)
+
+	@NotBlank(message = "nickname is mandatory")
+	private String nickname; //유저네임 (3~12자 이내, 문자/숫자 사용가능)
+
+	@NotBlank(message = "email is mandatory")
 	private String email;
+
+	@NotBlank(message = "findPw is mandatory")
 	private String findPw;
+
+	@NotBlank(message = "findPwQuestion is mandatory")
 	private String findPwQuestion;
 }

--- a/src/main/resources/static/css/signup.css
+++ b/src/main/resources/static/css/signup.css
@@ -1,0 +1,10 @@
+input[type="text"],
+input[type="password"],
+select {
+    width: 300px; /* 원하는 너비로 설정하세요 */
+}
+
+.error-message {
+    color: red;
+    font-size: 12px;
+}

--- a/src/main/resources/static/js/Signup.js
+++ b/src/main/resources/static/js/Signup.js
@@ -3,7 +3,9 @@ const duplicateIdCheckButton = document.querySelector("#duplicateIdCheckButton")
 const duplicateEmailCheckButton = document.querySelector("#duplicateEmailCheckButton");
 signUpBtn.addEventListener("click", () => {
     console.log("clicked")
-    signup();
+    if (validateForm()) {
+        signup();
+    }
 })
 
 duplicateIdCheckButton.addEventListener("click", async () => {
@@ -67,6 +69,22 @@ duplicateEmailCheckButton.addEventListener("click", async () => {
         alert("중복 확인에 실패했습니다. 다시 시도해주세요.");
     }
 });
+
+function validateForm() {
+    const userId = document.getElementById("userId").value.trim();
+    const password = document.getElementById("password").value.trim();
+    const nickname = document.getElementById("nickname").value.trim();
+    const email = document.getElementById("email").value.trim();
+    const findPw = document.getElementById("findPw").value.trim();
+    const findPwQuestion = document.getElementById("findPwQuestion").value;
+
+    if (!userId || !password || !nickname || !email || !findPw || !findPwQuestion) {
+        alert("모든 항목은 필수입니다.");
+        return false;
+    }
+
+    return true;
+}
 function signup() {
     var select = document.getElementById("findPwQuestion").value;
     switch (select) {
@@ -80,7 +98,6 @@ function signup() {
             select = "자신의 출신 초등학교는?";
             break;
     }
-    console.log("select: ", select);
     var formData = {
         userId: document.getElementById("userId").value,
         password: document.getElementById("password").value,
@@ -90,6 +107,14 @@ function signup() {
         findPw: document.getElementById("findPw").value
     };
 
+    console.log(formData.userId);
+    console.log(formData.password);
+    console.log(formData.nickname);
+    console.log(formData.email);
+    console.log(formData.findPwQuestion);
+    console.log(formData.findPw);
+
+
     fetch('/user', {
         method: 'POST',
         headers: {
@@ -98,6 +123,7 @@ function signup() {
         body: JSON.stringify(formData)
     })
         .then(response => {
+            console.log(response);
             if (response.ok) {
                 alert('회원가입이 완료되었습니다.');
                 window.location.href = '/login'; // 회원가입 완료 후 로그인 페이지로 이동

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -1,36 +1,43 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Keyboard Arena</title>
+    <link rel="stylesheet" type="text/css" href="/css/signup.css" th:href="@{/css/signup.css}">
     <script defer src="/js/Signup.js"></script>
 </head>
 <body>
 <h2>회원가입</h2>
 <form id="signupForm">
-    <label for="userId">아이디</label>
-    <input type="text" id="userId" name="userId" required>
+    <label for="userId" >아이디</label>
+    <input type="text" id="userId" name="userId" required placeholder="아이디 (6~12자 이내, 영문/숫자 사용가능)">
     <button id="duplicateIdCheckButton" type="button">중복확인</button><br><br>
 
     <label for="password">비밀번호</label>
-    <input type="password" id="password" name="password" required><br><br>
+    <input type="password" id="password" name="password" required placeholder="비밀번호(8~16자 이내, 영문/숫자/기호 사용가능)"><br><br>
 
     <label for="findPwQuestion">비밀번호 확인 질문</label>
-    <select name="questions" id="findPwQuestion" required>
+    <select name="questions" id="findPwQuestion" required >
+        <option value="" disabled selected>비밀번호 찾기에 사용할 질문을 선택하세요</option>
         <option value="place">기억에 남는 추억의 장소는?</option>
         <option value="treasure">자신의 보물 제1호는?</option>
         <option value="elementary">자신의 출신 초등학교는?</option>
-    </select><br><br>
+    </select>
+    <span class="error-message"></span><br><br>
 
     <label for="findPw">비밀번호 확인 답</label>
-    <input type="text" id="findPw" name="findPw" required><br><br>
+    <input type="text" id="findPw" name="findPw" required placeholder="비밀번호 찾기에 사용할 정답을 입력하세요">
+    <span class="error-message"></span><br><br>
 
     <label for="nickname">유저네임</label>
-    <input type="text" id="nickname" name="nickname" required><br><br>
+    <input type="text" id="nickname" name="nickname" required placeholder="유저네임 (3~12자 이내, 문자/숫자 사용가능)">
+    <span class="error-message" ></span><br><br>
 
     <label for="email">이메일</label>
-    <input type="email" id="email" name="email" required>
+    <input type="email" id="email" name="email" required placeholder="userid@company.com">
+    <span class="error-message" ></span>
+
     <button id="duplicateEmailCheckButton" type="button">중복확인</button><br><br>
 
     <button id="signupBtn" type="button">회원가입</button>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #1 

## 📝 구현 사항
<!-- 과제에 대한 설명을 적어주세요 -->
- ✔ 화면: `signup.tml`
- ✔ 회원가입 api url: `POST ~/user`
- 회원가입 시 모든 필드를 null / 빈 문자열 / 공백 문자열로 입력할 수 없도록 validation을 설정합니다.
  1. 브라우저 단에서 1차적으로 validateForm() js 메소드로 모든 필드를 필수적으로 입력하도록 alert를 출력합니다.
  2. AddUserRequest DTO에 spring boot starter validation @NotBlank 적용 
    -  validateForm() 메소드가 없더라도 서버 내부에서 빈 값이 조회되면 bindingResult에 에러가 발견되어 bad request를 반환합니다. 이어 기존 js 로직상 에러를 catch해 alert창에 `회원가입에 실패했습니다.`를 출력합니다. 


## TODO
- [ ] (아쉬운점) 실 원래 의도는 js 없이 스프링 validation만을 사용하는거긴 했음..