### PR TITLE
Feat: (마이페이지) 좋아요 누른 게시물 전체 조회 api 구현 + 작성한 게시물 전체 조회 api 정렬 및 포매팅

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -1,7 +1,6 @@
 package com.example.KeyboardArenaProject.controller.user;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
 import com.example.KeyboardArenaProject.entity.Board;
@@ -79,7 +78,6 @@ public class MyPageController {
             model.addAttribute("likedBoards", likedBoards);
             return "likedboards";
         } catch(MyPageService.MyLikeNotFoundExcpetion e) {
-            log.info("here........ㅠㅠ");
             String errorMessage = "좋아요를 누른 게시글이 없습니다";
             model.addAttribute("errorMessage", errorMessage);
             return "likedboards";

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -5,13 +5,17 @@ import java.util.stream.Collectors;
 
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
 import com.example.KeyboardArenaProject.entity.Board;
+import com.example.KeyboardArenaProject.entity.Like;
 import com.example.KeyboardArenaProject.entity.User;
 import com.example.KeyboardArenaProject.service.user.MyPageService;
 import com.example.KeyboardArenaProject.service.user.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+@Slf4j
 @Controller
 public class MyPageController {
     private final MyPageService myPageService;
@@ -58,4 +62,29 @@ public class MyPageController {
         }
 
     }
+
+    @GetMapping("/mypage/boards/liked")
+    public String getLikedBoards(Model model) {
+        User user = userService.getCurrentUserInfo();
+        String userId = user.getUserId();
+        try {
+            List<Like> likes = myPageService.getMyLikes(userId);
+            for(Like like : likes) {
+                log.info("MyPageController - getLikedBoards: 좋아요 boardId는 {}, id는 {}", like.getCompositeId().getBoardId(), like.getCompositeId().getId());
+            }
+            List<Board> likedBoards = myPageService.getMyLikedBoards(likes);
+            for(Board board: likedBoards) {
+                log.info("MyPageController - getLikedBoards: 좋아요 누른 게시글 boardId는 {}, id는 {}", board.getBoardId(), board.getId());
+            }
+            model.addAttribute("likedBoards", likedBoards);
+            return "likedboards";
+        } catch(MyPageService.MyLikeNotFoundExcpetion e) {
+            log.info("here........ㅠㅠ");
+            String errorMessage = "좋아요를 누른 게시글이 없습니다";
+            model.addAttribute("errorMessage", errorMessage);
+            return "likedboards";
+        }
+
+    }
+
 }

--- a/src/main/java/com/example/KeyboardArenaProject/repository/LikeRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/LikeRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Repository
 public interface LikeRepository extends JpaRepository<Like, UserBoardCompositeKey> {
     @Query(value = "UPDATE like_board SET if_like=:bool WHERE board_id=:boardId and id=:id", nativeQuery = true)
@@ -18,5 +20,5 @@ public interface LikeRepository extends JpaRepository<Like, UserBoardCompositeKe
     @Query(value = "SELECT COUNT(*) FROM like_board WHERE board_id=:boardId and if_like=true", nativeQuery = true )
     int countAllByBoardIdAndIfLikeIsTrue(String boardId);
 
-
+    List<Like> findByCompositeId_Id(String id);
 }

--- a/src/main/java/com/example/KeyboardArenaProject/repository/MyPageRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/MyPageRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface MyPageRepository extends JpaRepository<Board, String> {
     List<Board> findAllById(String id);
+    List<Board> findAllByBoardIdInOrderByCreatedDateDesc(List<String> boardIds);
 }

--- a/src/main/java/com/example/KeyboardArenaProject/repository/MyPageRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/MyPageRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MyPageRepository extends JpaRepository<Board, String> {
-    List<Board> findAllById(String id);
+    List<Board> findAllByIdOrderByCreatedDateDesc(String id);
     List<Board> findAllByBoardIdInOrderByCreatedDateDesc(List<String> boardIds);
 }

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
@@ -88,8 +88,12 @@ public class MyPageService {
 
     public List<Board> getMyLikedBoards(List<Like> likes) {
         List<String> boardIds = likes.stream()
-                .map(like -> like.getBoardId()).
+                .map(like -> like.getCompositeId().getBoardId()).
                 collect(Collectors.toList());
+        List<Board> myLikedBoards = myPageRepository.findAllByBoardIdInOrderByCreatedDateDesc(boardIds);
+        for (Board likedBoard : myLikedBoards) {
+            log.info("MyPageService - getMyLikedBoards: 작성일자 내림차순으로 조회한 좋아요 누른 게시물의 작성일자 : {}", likedBoard.getCreatedDate());
+        }
         return myPageRepository.findAllByBoardIdInOrderByCreatedDateDesc(boardIds);
     }
 

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
@@ -1,5 +1,4 @@
 package com.example.KeyboardArenaProject.service.user;
-
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
 import com.example.KeyboardArenaProject.entity.Board;
 import com.example.KeyboardArenaProject.entity.Like;
@@ -7,12 +6,9 @@ import com.example.KeyboardArenaProject.entity.User;
 import com.example.KeyboardArenaProject.repository.LikeRepository;
 import com.example.KeyboardArenaProject.repository.MyPageRepository;
 import com.example.KeyboardArenaProject.repository.UserRepository;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.ui.Model;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -67,7 +63,7 @@ public class MyPageService {
     }
 
     public List<Board> getMyBoards(String userId) {
-        List<Board> myBoards = myPageRepository.findAllById(userId);
+        List<Board> myBoards = myPageRepository.findAllByIdOrderByCreatedDateDesc(userId);
         if (myBoards.isEmpty()) {
             throw new MyBoardNotFoundException("작성한 게시글이 없습니다");
         }
@@ -80,7 +76,6 @@ public class MyPageService {
     public List<Like> getMyLikes(String userId) {
         List<Like> myLikes = likeRepository.findByCompositeId_Id(userId);
         if(myLikes.isEmpty()) {
-            log.info("here.....");
             throw new MyLikeNotFoundExcpetion("좋아요를 누른 게시글이 없습니다");
         }
         return likeRepository.findByCompositeId_Id(userId);

--- a/src/main/resources/templates/likedboards.html
+++ b/src/main/resources/templates/likedboards.html
@@ -25,8 +25,7 @@
             <td th:text="${index.index + 1}"></td>
             <td th:text="${board.title}"></td>
             <td th:text="${board.id}"></td>
-            <td th:text="${board.createdDate}"></td>
-            <!--            <td th:text="${#dates.format(board.createdDate, 'yyyy.MM.dd')}"></td>-->
+            <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
             <td th:text="${board.likes}"></td>
         </tr>
     </tbody>

--- a/src/main/resources/templates/likedboards.html
+++ b/src/main/resources/templates/likedboards.html
@@ -6,25 +6,27 @@
 </head>
 <body>
 <h1>My Page</h1>
-<h2>내가 쓴 게시물</h2>
-<div th:unless="${myBoards}">
+<h2>좋아요 누른 게시물</h2>
+<div th:unless="${likedBoards}">
     <p th:text="${errorMessage}"></p>
 </div>
-<table th:if="${myBoards}">
+<table th:if="${likedBoards}">
     <thead>
         <tr>
             <th>번호</th>
             <th>제목</th>
+            <th>작성자</th>
             <th>작성일</th>
             <th>좋아요</th>
         </tr>
     </thead>
     <tbody>
-        <tr th:each="board, index : ${myBoards}">
+        <tr th:each="board, index : ${likedBoards}">
             <td th:text="${index.index + 1}"></td>
             <td th:text="${board.title}"></td>
+            <td th:text="${board.id}"></td>
             <td th:text="${board.createdDate}"></td>
-<!--            <td th:text="${#dates.format(board.createdDate, 'yyyy.MM.dd')}"></td>-->
+            <!--            <td th:text="${#dates.format(board.createdDate, 'yyyy.MM.dd')}"></td>-->
             <td th:text="${board.likes}"></td>
         </tr>
     </tbody>

--- a/src/main/resources/templates/myboards.html
+++ b/src/main/resources/templates/myboards.html
@@ -23,8 +23,7 @@
         <tr th:each="board, index : ${myBoards}">
             <td th:text="${index.index + 1}"></td>
             <td th:text="${board.title}"></td>
-            <td th:text="${board.createdDate}"></td>
-<!--            <td th:text="${#dates.format(board.createdDate, 'yyyy.MM.dd')}"></td>-->
+            <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
             <td th:text="${board.likes}"></td>
         </tr>
     </tbody>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -16,6 +16,7 @@
 </div>
 <div>
     <a href="/mypage/boards">내가 쓴 게시물</a>
+    <a href="/mypage/boards/liked">좋아요 누른 게시물</a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #4 

## 📝 구현 사항
<!-- 과제에 대한 설명을 적어주세요 -->
- 좋아요 누른 게시물 전체 조회 api를 구현하고 LocalDateTime을 보기좋게 포매팅, 내림차순 정렬이 적용되지 않았던 부분을 수정했습니다
- ✔ 화면: `mypage.html` 마이페이지 첫 화면 -> 'likeboards.html' 좋아요 누른 게시글 조회 화면
- ✔ 마이페이지 작성한 게시물 전체 조회 api url: `GET ~/mypage/boards`
- ✔ 마이페이지 좋아요 누른 게시물 전체 조회 api url: `GET ~/mypage/boards/liked`

## 캡쳐

🔽 마이페이지 접속 시 보이는 첫 화면
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/f52723e0-a91e-4e19-87c0-7c0ee0021981" width="30%">

🔽 '좋아요 누른 게시물' 링크 클릭 시 조회되는 게시물 목록 table
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/792e8776-471a-4466-93c2-6e61c9896d94" width="40%">


## TODO
- [ ] ❗❗ 작성한 게시물 row 누르면 게시물 세부 페이지로 넘어가도록 적용
- [ ] ❗❗ 좋아요 누른 게시물 row 누르면 게시물 세부 페이지로 넘어가도록 적용