### PR TITLE
Feat: (마이페이지) 비밀번호 변경 api 구현

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -2,6 +2,7 @@ package com.example.KeyboardArenaProject.controller.user;
 
 import java.util.List;
 
+import com.example.KeyboardArenaProject.dto.user.ChangePwRequest;
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
 import com.example.KeyboardArenaProject.entity.Board;
 import com.example.KeyboardArenaProject.entity.Like;
@@ -9,10 +10,15 @@ import com.example.KeyboardArenaProject.entity.User;
 import com.example.KeyboardArenaProject.service.user.MyPageService;
 import com.example.KeyboardArenaProject.service.user.UserService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Slf4j
 @Controller
@@ -42,6 +48,25 @@ public class MyPageController {
         MyPageInformation userInfo = myPageService.getUserInfo(currentUserId);
         model.addAttribute("userInfo", userInfo);
         return "mypage";
+    }
+
+    @GetMapping("/mypage/changePassword")
+    public String showChangePasswordForm() {
+        return "changePw";
+    }
+
+    @PostMapping("/mypage/changePassword")
+    @ResponseBody
+    public ResponseEntity<String> changePassword(@RequestBody ChangePwRequest changePwRequest) {
+        try {
+            myPageService.changePassword(changePwRequest.getCurrentPassword(), changePwRequest.getNewPassword(), changePwRequest.getConfirmNewPassword());
+            log.info("비밀번호가 성공적으로 변경되었습니다.");
+            return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+        } catch (MyPageService.CurrentPasswordMismatchException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("현재 비밀번호가 일치하지 않습니다.");
+        } catch (MyPageService.NewPasswordMismatchException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("새로운 비밀번호와 새로운 비밀번호 확인 비밀번호가 일치하지 않습니다.");
+        }
     }
 
     @GetMapping("/mypage/boards")

--- a/src/main/java/com/example/KeyboardArenaProject/dto/user/ChangePwRequest.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/user/ChangePwRequest.java
@@ -1,0 +1,10 @@
+package com.example.KeyboardArenaProject.dto.user;
+
+import lombok.Data;
+
+@Data
+public class ChangePwRequest {
+    private String currentPassword;
+    private String newPassword;
+    private String confirmNewPassword;
+}

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
@@ -41,10 +41,10 @@ public class MyPageService {
     }
 
     // 비밀번호 변경
-    public void changePassword(String currentPassword, String newPassword, String confirmPassword) {
+    public void changePassword(String currentPassword, String newPassword, String confirmNewPassword) {
         // 현재 로그인한 사용자 정보
         User currentUser = userService.getCurrentUserInfo();
-        log.info("비밀번호 변경을 시도하는 사용자 정보 - {}", currentUser);
+        log.info("비밀번호 변경을 시도하는 사용자ID - {}", currentUser.getUserId());
 
         // 현재 비밀번호 확인
         if (!encoder.matches(currentPassword, currentUser.getPassword())) {
@@ -53,13 +53,14 @@ public class MyPageService {
         }
 
         // 새로운 비밀번호 확인
-        if (!newPassword.equals(confirmPassword)) {
+        if (!newPassword.equals(confirmNewPassword)) {
             log.warn("새로운 비밀번호와 새로운 비밀번호 확인 비밀번호가 일치하지 않습니다.");
             throw new NewPasswordMismatchException("새로운 비밀번호와 새로운 비밀번호 확인 비밀번호가 일치하지 않습니다.");
         }
         // 새로운 비밀번호 변경
         currentUser.setPassword(encoder.encode(newPassword));
-
+        userRepository.save(currentUser);
+        log.info("사용자 {}의 비밀번호가 성공적으로 변경되었습니다!", currentUser.getUserId());
     }
 
     public List<Board> getMyBoards(String userId) {

--- a/src/main/resources/static/js/ChangePw.js
+++ b/src/main/resources/static/js/ChangePw.js
@@ -1,0 +1,34 @@
+document.getElementById("changePasswordForm").addEventListener("submit", function (event) {
+    event.preventDefault();
+
+    var formData = new FormData(this);
+    var currentPassword = formData.get("currentPassword");
+    var newPassword = formData.get("newPassword");
+    var confirmNewPassword = formData.get("confirmNewPassword");
+
+    fetch("/mypage/changePassword", {
+        method: "POST",
+        body: JSON.stringify({
+            currentPassword: currentPassword,
+            newPassword: newPassword,
+            confirmNewPassword: confirmNewPassword
+        }),
+        headers: {
+            "Content-Type": "application/json"
+        }
+    }).then(function (response) {
+        if (response.ok) {
+            // 비밀번호가 성공적으로 변경되었을 때
+            alert("비밀번호가 성공적으로 변경되었습니다.");
+            window.location.href = "/mypage"; // 성공적으로 변경되었을 때 /mypage로 리다이렉트
+        } else if (response.status === 400) {
+            response.text().then(function (errorMessage) {
+                // 서버에서 반환한 오류 메시지를 받아와서 처리
+                alert(errorMessage);
+            });
+        } else {
+            // 기타 오류가 발생했을 때
+            alert("서버와의 통신 중 문제가 발생했습니다. 나중에 다시 시도해주세요.");
+        }
+    });
+});

--- a/src/main/resources/templates/changePw.html
+++ b/src/main/resources/templates/changePw.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 변경</title>
+    <script defer src="/js/ChangePw.js"></script>
+</head>
+<body>
+
+<header>
+    <h1>Keyboard Arena</h1>
+    <h2>MyPage</h2>
+</header>
+
+<main>
+    <h2>비밀번호 변경</h2>
+    <form id ="changePasswordForm" action="/mypage/changePassword" method="post">
+        <div>
+            <label for="currentPassword">현재 비밀번호:</label>
+            <input type="password" id="currentPassword" name="currentPassword" required>
+        </div>
+        <div>
+            <label for="newPassword">새로운 비밀번호:</label>
+            <input type="password" id="newPassword" name="newPassword" required>
+        </div>
+        <div>
+            <label for="confirmNewPassword">새로운 비밀번호 확인:</label>
+            <input type="password" id="confirmNewPassword" name="confirmNewPassword" required>
+        </div>
+        <button type="submit">변경</button>
+    </form>
+</main>
+
+</body>
+</html>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -14,6 +14,9 @@
     <p>Point: <span th:text="${userInfo.point}"></span></p>
     <p>Email: <span th:text="${userInfo.email}"></span></p>
 </div>
+    <form action="/mypage/changePassword" method="get">
+        <button type="submit">비밀번호 변경</button>
+    </form>
 <div>
     <a href="/mypage/boards">내가 쓴 게시물</a>
     <a href="/mypage/boards/liked">좋아요 누른 게시물</a>


### PR DESCRIPTION
### 📌 관련 이슈

-----------------------------------------------------------------------------------------------------------------------------------------
#4 

### 📝 구현 사항

-----------------------------------------------------------------------------------------------------------------------------------------

- ✔ 화면: mypage.html 마이페이지 첫 화면, 비밀번호 변경 클릭 시 -> 'changePw.html' 비밀번호 변경 화면
`GET ~/mypage/changePassword`

- ✔ 비밀번호 변경 api url
`POST ~/mypage/changePassword`

- 현재 비밀번호와 새로운 비밀번호, 새로운 비밀번호 확인 입력을 통해 비밀번호가 변경 되며
/mypage로 되돌아갑니다.

- 현재 비밀번호 값이 다른 상태로 비밀번호 변경 시
 "현재 비밀번호가 일치하지 않습니다." 메세지를 출력합니다.

- 새로운 비밀번호와 새로운 비밀번호 입력 값이 다른 상태로 비밀번호 변경 시
"새로운 비밀번호와 새로운 비밀번호 확인 비밀번호가 일치하지 않습니다." 메세지를 출력합니다.

### 캡쳐
-----------------------------------------------------------------------------------------------------------------------------------------
🔽 마이페이지 첫 화면

![image](https://github.com/Garodden/keyboard-arena/assets/155498542/6fa862e5-8032-4b50-83c8-b3a877984fb8)

🔽 비밀번호 변경 첫 화면

![image](https://github.com/Garodden/keyboard-arena/assets/155498542/d138eb1b-0255-429c-82ae-335d846d3935)

🔽 현재 비밀번호, 새로운 비밀번호, 새로운 비밀번호 확인 값이 모두 일치하면, alert 출력

![비밀번호_성공_2](https://github.com/Garodden/keyboard-arena/assets/155498542/02821f1c-c868-41f0-9157-fe1b2660d3a4)

🔽 현재 비밀번호 값이 일치하지 않는 상태라면, alert 출력

![비밀번호_실패_현재비번](https://github.com/Garodden/keyboard-arena/assets/155498542/3e26d1b7-a69f-4572-8597-856a6b69f72e)

🔽 새로운 비밀번호와 새로운 비밀번호 확인 값이 일치하지 않는 상태라면, alert 출력

![비밀번호_실패_새로운비번](https://github.com/Garodden/keyboard-arena/assets/155498542/29f0430c-9ea2-4ec4-8314-7e93b53a9f38)

