### PR TITLE
Feat: (마이페이지) 참전한 아레나 전체 조회 api

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -2,10 +2,10 @@ package com.example.KeyboardArenaProject.controller.user;
 
 import java.util.List;
 
+import com.example.KeyboardArenaProject.dto.mypage.MyArenaResponse;
 import com.example.KeyboardArenaProject.dto.user.ChangePwRequest;
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
 import com.example.KeyboardArenaProject.entity.Board;
-import com.example.KeyboardArenaProject.entity.Cleared;
 import com.example.KeyboardArenaProject.entity.Like;
 import com.example.KeyboardArenaProject.entity.User;
 import com.example.KeyboardArenaProject.service.user.MyPageService;
@@ -13,7 +13,6 @@ import com.example.KeyboardArenaProject.service.user.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -76,9 +75,6 @@ public class MyPageController {
         User user = userService.getCurrentUserInfo();
         try {
             List<Board> myBoards = myPageService.getMyBoards(user.getId());
-            // List<String> formattedDates = myBoards.stream()
-            //     .map(board -> formatDate(board.getCreatedDate()))
-            //     .collect(Collectors.toList());
             model.addAttribute("myBoards", myBoards);
             return "myboards";
         } catch (MyPageService.MyBoardNotFoundException e) {
@@ -117,10 +113,11 @@ public class MyPageController {
     public String getMyArenas(Model model) {
         User user = userService.getCurrentUserInfo();
         String id = user.getId();
-        List<String> myArenasFromCleared = myPageService.getMyArenasFromCleared(id);
-        List<Board> myArenasFromBoard = myPageService.getMyArenasFromBoard(myArenasFromCleared);
-        for(Board arena: myArenasFromBoard) {
-            log.info("MyPageController - getMyArenas: 내가 참전한 아레나 조회 boardId {}, id {}, title {}", arena.getBoardId(), arena.getId(), arena.getTitle());
+        List<String> boardIdsFromCleared = myPageService.getMyArenasFromCleared(id);
+        List<MyArenaResponse> myArenasFromBoard = myPageService.getMyArenaDetailsFromBoard(boardIdsFromCleared);
+        for(MyArenaResponse arena: myArenasFromBoard) {
+            log.info("MyPageController - getMyArenas: 내가 참전한 아레나 조회 title {}, rank {}, createdDate {}, participates {}, comments {}, likes {}",
+                arena.getTitle(), arena.getBoardRank(), arena.getCreatedDate(), arena.getParticipates(), arena.getComments(), arena.getLikes());
         }
         model.addAttribute("myArenas", myArenasFromBoard);
         return "myArenas";

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.example.KeyboardArenaProject.dto.user.ChangePwRequest;
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
 import com.example.KeyboardArenaProject.entity.Board;
+import com.example.KeyboardArenaProject.entity.Cleared;
 import com.example.KeyboardArenaProject.entity.Like;
 import com.example.KeyboardArenaProject.entity.User;
 import com.example.KeyboardArenaProject.service.user.MyPageService;
@@ -59,7 +60,8 @@ public class MyPageController {
     @ResponseBody
     public ResponseEntity<String> changePassword(@RequestBody ChangePwRequest changePwRequest) {
         try {
-            myPageService.changePassword(changePwRequest.getCurrentPassword(), changePwRequest.getNewPassword(), changePwRequest.getConfirmNewPassword());
+            myPageService.changePassword(changePwRequest.getCurrentPassword(), changePwRequest.getNewPassword(),
+                changePwRequest.getConfirmNewPassword());
             log.info("비밀번호가 성공적으로 변경되었습니다.");
             return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
         } catch (MyPageService.CurrentPasswordMismatchException e) {
@@ -79,7 +81,7 @@ public class MyPageController {
             //     .collect(Collectors.toList());
             model.addAttribute("myBoards", myBoards);
             return "myboards";
-        } catch(MyPageService.MyBoardNotFoundException e) {
+        } catch (MyPageService.MyBoardNotFoundException e) {
             String errorMessage = "작성한 게시글이 없습니다";
             model.addAttribute("errorMessage", errorMessage);
             return "myboards";
@@ -93,21 +95,34 @@ public class MyPageController {
         String userId = user.getUserId();
         try {
             List<Like> likes = myPageService.getMyLikes(userId);
-            for(Like like : likes) {
-                log.info("MyPageController - getLikedBoards: 좋아요 boardId는 {}, id는 {}", like.getCompositeId().getBoardId(), like.getCompositeId().getId());
+            for (Like like : likes) {
+                log.info("MyPageController - getLikedBoards: 좋아요 boardId는 {}, id는 {}",
+                    like.getCompositeId().getBoardId(), like.getCompositeId().getId());
             }
             List<Board> likedBoards = myPageService.getMyLikedBoards(likes);
-            for(Board board: likedBoards) {
-                log.info("MyPageController - getLikedBoards: 좋아요 누른 게시글 boardId는 {}, id는 {}", board.getBoardId(), board.getId());
+            for (Board board : likedBoards) {
+                log.info("MyPageController - getLikedBoards: 좋아요 누른 게시글 boardId는 {}, id는 {}", board.getBoardId(),
+                    board.getId());
             }
             model.addAttribute("likedBoards", likedBoards);
             return "likedboards";
-        } catch(MyPageService.MyLikeNotFoundExcpetion e) {
+        } catch (MyPageService.MyLikeNotFoundExcpetion e) {
             String errorMessage = "좋아요를 누른 게시글이 없습니다";
             model.addAttribute("errorMessage", errorMessage);
             return "likedboards";
         }
-
     }
 
+    @GetMapping("/mypage/arenas")
+    public String getMyArenas(Model model) {
+        User user = userService.getCurrentUserInfo();
+        String id = user.getId();
+        List<String> myArenasFromCleared = myPageService.getMyArenasFromCleared(id);
+        List<Board> myArenasFromBoard = myPageService.getMyArenasFromBoard(myArenasFromCleared);
+        for(Board arena: myArenasFromBoard) {
+            log.info("MyPageController - getMyArenas: 내가 참전한 아레나 조회 boardId {}, id {}, title {}", arena.getBoardId(), arena.getId(), arena.getTitle());
+        }
+        model.addAttribute("myArenas", myArenasFromBoard);
+        return "myArenas";
+    }
 }

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -113,13 +113,8 @@ public class MyPageController {
     public String getMyArenas(Model model) {
         User user = userService.getCurrentUserInfo();
         String id = user.getId();
-        List<String> boardIdsFromCleared = myPageService.getMyArenasFromCleared(id);
-        List<MyArenaResponse> myArenasFromBoard = myPageService.getMyArenaDetailsFromBoard(boardIdsFromCleared);
-        for(MyArenaResponse arena: myArenasFromBoard) {
-            log.info("MyPageController - getMyArenas: 내가 참전한 아레나 조회 title {}, rank {}, createdDate {}, participates {}, comments {}, likes {}",
-                arena.getTitle(), arena.getBoardRank(), arena.getCreatedDate(), arena.getParticipates(), arena.getComments(), arena.getLikes());
-        }
-        model.addAttribute("myArenas", myArenasFromBoard);
+        List<MyArenaResponse> myArenaDetails = myPageService.getMyArenaDetails(id);
+        model.addAttribute("myArenas", myArenaDetails);
         return "myArenas";
     }
 }

--- a/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyArenaResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyArenaResponse.java
@@ -17,9 +17,10 @@ public class MyArenaResponse {
 	int participates;
 	int comments;
 	int likes;
+	double percentage;
 
 	@Builder
-	MyArenaResponse(Board board, int participates) {
+	MyArenaResponse(Board board, int participates, double percentage) {
 		this.boardId = board.getBoardId();
 		this.boardType = board.getBoardType();
 		this.title = board.getTitle();
@@ -28,5 +29,6 @@ public class MyArenaResponse {
 		this.participates = participates;
 		this.comments =board.getComments();
 		this.likes = board.getLikes();
+		this.percentage = percentage;
 	}
 }

--- a/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyArenaResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyArenaResponse.java
@@ -1,0 +1,32 @@
+package com.example.KeyboardArenaProject.dto.mypage;
+import com.example.KeyboardArenaProject.entity.Board;
+import lombok.*;
+import java.time.LocalDateTime;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyArenaResponse {
+	String boardId;
+	int boardType;
+	String title;
+	int boardRank;
+	LocalDateTime createdDate;
+	int participates;
+	int comments;
+	int likes;
+
+	@Builder
+	MyArenaResponse(Board board, int participates) {
+		this.boardId = board.getBoardId();
+		this.boardType = board.getBoardType();
+		this.title = board.getTitle();
+		this.boardRank = board.getBoardRank();
+		this.createdDate = board.getCreatedDate();
+		this.participates = participates;
+		this.comments =board.getComments();
+		this.likes = board.getLikes();
+	}
+}

--- a/src/main/java/com/example/KeyboardArenaProject/repository/ClearedRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/ClearedRepository.java
@@ -23,5 +23,5 @@ public interface ClearedRepository extends JpaRepository<Cleared, UserBoardCompo
 
     Cleared findByCompositeId(UserBoardCompositeKey curUsersClearRecord);
 
-
+    List<Cleared> findAllByCompositeId_idOrderByStartTimeDesc(String id);
 }

--- a/src/main/resources/static/js/MyPageGetBoardDetails.js
+++ b/src/main/resources/static/js/MyPageGetBoardDetails.js
@@ -8,6 +8,7 @@ rows.forEach(row => {
             window.location.href = `/board/${boardId}`;
         } else if (boardType === "2" || boardType === "3") {
             window.location.href = `/arenas/${boardId}`;
+            console.log(window.location.href);
         }
     })
 })

--- a/src/main/resources/templates/myArenas.html
+++ b/src/main/resources/templates/myArenas.html
@@ -20,9 +20,10 @@
         <th>Arena 제목</th>
         <th>랭크</th>
         <th>작성일</th>
-        <th>참가자 수</th>
+        <th>참가자</th>
         <th>댓글</th>
         <th>좋아요</th>
+        <th>N%</th>
     </tr>
     </thead>
     <tbody>
@@ -34,6 +35,7 @@
         <td th:text="${arena.participates}"></td>
         <td th:text="${arena.comments}"></td>
         <td th:text="${arena.likes}"></td>
+        <td th:text="${arena.percentage + '%'}"></td>
     </tr>
     </tbody>
 </table>

--- a/src/main/resources/templates/myArenas.html
+++ b/src/main/resources/templates/myArenas.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Keyboard Arena</title>
+    <link rel="stylesheet" type="text/css" href="/css/MyPageBoards.css" th:href="@{/css/MyPageBoards.css}">
+    <script defer src="/js/MyPageGetBoardDetails.js"></script>
+</head>
+<body>
+<h1>Keyboard Arena</h1>
+<h2>My Page</h2>
+<h3>내가 참전한 아레나</h3>
+<div th:unless="${myArenas}">
+    <p th:text="${errorMessage}"></p>
+</div>
+<table th:if="${myArenas}">
+    <thead>
+    <tr>
+        <th>번호</th>
+        <th>Arena 제목</th>
+        <th>랭크</th>
+        <th>작성일</th>
+        <th>참가자 수</th>
+        <th>댓글</th>
+        <th>좋아요</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="arena, index : ${myArenas}" class="clickable-row" th:attr="board-id=${arena.getBoardId()}, board-type=${arena.boardType}">
+        <td th:text="${index.index + 1}"></td>
+        <td th:text="${arena.title}"></td>
+        <td th:text="${arena.boardRank}"></td>
+        <td th:text="${#temporals.format(arena.createdDate, 'yyyy.MM.dd')}"></td>
+        <td th:text="${arena.participates}"></td>
+        <td th:text="${arena.comments}"></td>
+        <td th:text="${arena.likes}"></td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</body>
+</html>

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -18,8 +18,10 @@
         <button type="submit">비밀번호 변경</button>
     </form>
 <div>
-    <a href="/mypage/boards">내가 쓴 게시물</a>
-    <a href="/mypage/boards/liked">좋아요 누른 게시물</a>
+    <a href="/mypage/arenas">내가 참전한 아레나</a><br>
+    <a href="#">내가 댓글 단 게시물</a><br>
+    <a href="/mypage/boards">내가 쓴 게시물</a><br>
+    <a href="/mypage/boards/liked">좋아요 누른 게시물</a><br>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #4 

## 📝 구현 사항
### 피그마 UI
<!-- 과제에 대한 설명을 적어주세요 -->
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/09b7bcd6-070d-4abb-bec2-d372832b0219" width="50%">

- 참전한 아레나 전체를 조회하고 개별 클릭시 아레나 세부 페이지로 넘어갑니다
- ✔ 화면: `mypage.html` 마이페이지 첫 화면 -> 'myarenas.html' 참전한 아레나 전체 조회 화면
- ✔ 마이페이지 참전한 아레나 전체 조회 api url: `GET ~/mypage/arenas`

### 캡쳐
🔽 마이페이지 첫 화면
댓글단 게시물 전체조회 딱기다려
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/6bcb11f1-34c1-491f-9367-de4ac1e7124f" width="30%">

🔽 참전한 아레나 전체 조회 -> 참전한 아레나 개별 조회
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/933d45d3-8314-4e0f-915a-b56968bffe9b" width="60%">

🔽 위의 상태에서 첫번째 row를 클릭하면..
<img src="https://github.com/Garodden/keyboard-arena/assets/82032418/7ece4c36-3542-4a74-9681-b6b28647690b" width="40%">


