### PR TITLE
Feat/#5 arena verify 아레나 활성화 전 자격 시험 단계 구현

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/controller/arena/ArenaController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/arena/ArenaController.java
@@ -63,13 +63,16 @@ public class ArenaController {
 
         Board arenaRawInfo = arenaService.findByBoardId(boardId);
         User user = userService.getCurrentUserInfo();
-        boolean ifFirstTry = !clearedService.findIfUserClearDataExists(UserBoardCompositeKey
+        UserBoardCompositeKey curKey = UserBoardCompositeKey
                 .builder()
                 .id(user.getId())
                 .boardId(arenaRawInfo.getBoardId())
-                .build());
+                .build();
 
-
+        boolean ifFirstTry = false;
+        if(clearedService.findIfUserDataExists(curKey)&&clearedService.findIfUserClearDataExists(curKey)){
+            ifFirstTry = true;
+        }
         ArenaDetailResponse arenaDetails = ArenaDetailResponse
                 .builder()
                 .user(user)
@@ -94,17 +97,12 @@ public class ArenaController {
         //클리어 보드에 현재 시작한 시간을 기록
         //만약 클리어 기록이 존재하면 해당 기록에서 시간 기록 시작
         //아니라면 새로운 기록 생성, 시간 기록 시작
-        if(clearedService.findIfUserClearDataExists(curUsersClearRecord)){
+        if(clearedService.findIfUserDataExists(curUsersClearRecord)){
             clearedService.updateStartTime(curUsersClearRecord);
-            //
+
         }
         else {
-            Cleared cleared = Cleared.builder()
-                    .boardId(boardId)
-                    .id(user.getId())
-                    .startTime(LocalDateTime.now())
-                    .build();
-            clearedService.saveClearStartTime(cleared);
+            clearedService.saveCleared(user.getId(), boardId);
         }
 
         return ResponseEntity.ok(new ArenaStartTimeResponse(LocalDateTime.now()));
@@ -156,26 +154,104 @@ public class ArenaController {
         return "newArena";
     }
 
-    @Operation(summary = "아레나 제작", description = "아레나 개장 Post 메소드 API")
+    @Operation(summary = "아레나 제작", description = "아레나 개장 Post 메소드 API 개장한 arena의 boardId를 알려준다")
     @PostMapping("/newArena")
+    @ResponseBody
     public String addNewArena(@RequestBody ArenaReceiveForm request) {
 
-        User currentUser = userService.getCurrentUserInfo();
+        User curUser = userService.getCurrentUserInfo();
 
         //콘텐트 양 옆의 whitespace 문자 제거.
         String strippedContent = request.getContent().strip();
 
         Board arena = Board.builder()
-                .id(currentUser.getId())
+                .id(curUser.getId())
                 .title(request.getTitle())
                 .content(strippedContent)
-                .board_rank(currentUser.getUserRank())
+                .board_rank(curUser.getUserRank())
                 .board_type(3)
                 .active(false)
                 .build();
 
         arenaService.saveArena(arena);
-        return "redirect:/arena"+arena.getBoardId()+"/verify";
+        return arena.getBoardId();
+    }
+
+
+    @Operation(summary = "제작한 아레나 활성화 전 검증 사이트 API", description = "아레나 개장 Post 메소드 API")
+    @GetMapping("/arena/{boardId}/verify")
+    public String addNewArena(@PathVariable String boardId, Model model ) {
+
+        User currentUser = userService.getCurrentUserInfo();
+        Board currentBoard = arenaService.findByBoardId(boardId);
+
+        ArenaVerifyResponse verifyResponse = ArenaVerifyResponse
+                .builder()
+                .board(currentBoard)
+                .user(currentUser)
+                .writer(userService.getNickNameById(currentBoard.getId()))
+                .build();
+
+        model.addAttribute("arena", verifyResponse);
+
+        return "arenaVerify";
+    }
+
+    @Operation(summary = "아레나 검증 시작 시간 기록", description = "검증 시작 시간을 기록하는 용도, 시작 시간을 기록함")
+    @GetMapping("/arenas/{boardId}/verify/start")
+    @ResponseBody
+    public ResponseEntity<ArenaStartTimeResponse> markArenaVerifyStartTime(@PathVariable String boardId){
+
+        User user = userService.getCurrentUserInfo();
+        UserBoardCompositeKey curUsersClearRecord = UserBoardCompositeKey.builder().id(user.getId()).boardId(boardId).build();
+        //클리어 보드에 현재 시작한 시간을 기록
+        //만약 클리어 기록이 존재하면 해당 기록에서 시간 기록 시작
+        //아니라면 새로운 기록 생성, 시간 기록 시작
+        if(clearedService.findIfUserDataExists(curUsersClearRecord)){
+            clearedService.updateStartTime(curUsersClearRecord);
+        }
+        else {
+            clearedService.saveCleared(user.getId(), boardId);
+        }
+
+        return ResponseEntity.ok(new ArenaStartTimeResponse(LocalDateTime.now()));
+    }
+
+
+
+    @Operation(summary = "제작한 아레나 게시 전 검증 사이트 API", description = "유저가 해당 아레나를 클리어한 시간이 120초 이하면 아레나를 활성화시켜준다.")
+    @PostMapping("/arena/{boardId}/verify")
+    @ResponseBody
+    public String addNewArena(@PathVariable String boardId, @RequestParam String userTypedText) {
+
+        Board curBoard = arenaService.findByBoardId(boardId);
+        User curUser = userService.getCurrentUserInfo();
+
+        UserBoardCompositeKey curKey = UserBoardCompositeKey.builder()
+                .id(curUser.getId())
+                .boardId(boardId)
+                .build();
+
+        String originalContent = curBoard.getContent().trim();
+        String userTypedContent= userTypedText.trim();
+
+        clearedService.getOnlyClearTime(curKey);
+
+        ArenaVerifyResultResponse result = ArenaVerifyResultResponse
+                .builder()
+                .clearTimeBySeconds(clearedService.getOnlyClearTime(curKey))
+                .title(curBoard.getTitle())
+                .build();
+
+        if(originalContent.equals(userTypedContent)&&
+                result.getClearTimeBySeconds()<=120){
+            clearedService.updateClearTime(curKey);
+            arenaService.updateActive(curBoard.getBoardId());
+            return result.resultPopupText(true);
+        }
+        else {
+            return result.resultPopupText(false);
+        }
     }
 
 

--- a/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaVerifyResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaVerifyResponse.java
@@ -1,0 +1,35 @@
+package com.example.KeyboardArenaProject.dto.arena;
+
+import com.example.KeyboardArenaProject.dto.user.UserTopBarInfo;
+import com.example.KeyboardArenaProject.entity.Board;
+import com.example.KeyboardArenaProject.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ArenaVerifyResponse {
+    UserTopBarInfo userTopBarInfo;
+    String boardId;
+    String title;
+    String content;
+    String writer;
+    LocalDateTime createdDate;
+    int boardRank;
+
+    @Builder ArenaVerifyResponse(User user, Board board, String writer){
+        this.userTopBarInfo = new UserTopBarInfo(user);
+        this.title = board.getTitle();
+        this.content = board.getContent();
+        this.boardId = board.getBoardId();
+        this.writer =writer;
+        this.boardRank = board.getBoardRank();
+        this.createdDate = board.getCreatedDate();
+
+    }
+}

--- a/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaVerifyResultResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/arena/ArenaVerifyResultResponse.java
@@ -1,0 +1,34 @@
+package com.example.KeyboardArenaProject.dto.arena;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class ArenaVerifyResultResponse {
+    String title;
+    Long clearTimeBySeconds;
+
+
+    @Builder
+    ArenaVerifyResultResponse(String title, Long clearTimeBySeconds) {
+        this.title = title;
+        this.clearTimeBySeconds = clearTimeBySeconds;
+    }
+
+    public String resultPopupText(Boolean ifCleared){
+        if(ifCleared) {
+            return "축하합니다 !\n" +
+                    title + " 아레나를" +
+                    clearTimeBySeconds.toString() + "초에 클리어 하셨군요!\n" +
+                    "아레나 게시판에 등록을 성공하였습니다!";
+        }
+        else{
+            return title + " 아레나를 120초 내에 클리어하지 못했습니다. 다시 시도해보세요!";
+        }
+    }
+}

--- a/src/main/java/com/example/KeyboardArenaProject/entity/Board.java
+++ b/src/main/java/com/example/KeyboardArenaProject/entity/Board.java
@@ -84,5 +84,9 @@ public class Board {
         return new FreeBoardResponse(id,title,content,boardType,createdDate,updatedDate,boardRank);
     }
 
+    public void updateToActive(){
+        this.ifActive = true;
+    }
+
 
 }

--- a/src/main/java/com/example/KeyboardArenaProject/entity/Cleared.java
+++ b/src/main/java/com/example/KeyboardArenaProject/entity/Cleared.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicInsert;
 import org.springframework.cglib.core.Local;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 import java.time.Duration;
@@ -20,6 +21,7 @@ import java.time.LocalTime;
 @Entity
 @NoArgsConstructor
 @DynamicInsert
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "user_cleared_board")
 public class Cleared {
 
@@ -56,12 +58,19 @@ public class Cleared {
         return clearTime;
     }
 
+    public LocalTime updateClearTime(Long seconds){
+        this.clearTime = LocalTime.ofSecondOfDay(seconds % (24 * 3600));
+        this.tries+=1;
+        return clearTime;
+    }
+
+
     public String getId(){
         return compositeId.getId();
     }
 
     public String getBoardId(){
-        return compositeId.getId();
+        return compositeId.getBoardId();
     }
 
     public void setId(String id){

--- a/src/main/java/com/example/KeyboardArenaProject/repository/ClearedRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/ClearedRepository.java
@@ -13,8 +13,11 @@ import java.util.List;
 public interface ClearedRepository extends JpaRepository<Cleared, UserBoardCompositeKey> {
     List<Cleared> findAllByCompositeId_BoardId(String boardId);
 
+    //클리어 데이터가 있는지
     @Query("SELECT CASE WHEN e.clearTime is NULL then false ELSE true END FROM Cleared  e where e.compositeId =:id")
     Boolean ifClearedById(UserBoardCompositeKey id);
+
+    //유저 데이터가 있는지
 
     Long countByCompositeId_BoardId(String boardId);
 

--- a/src/main/java/com/example/KeyboardArenaProject/service/arena/ArenaService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/arena/ArenaService.java
@@ -40,6 +40,9 @@ public class ArenaService {
         boardRepository.save(Arena);
     }
 
-
-
+    @Transactional
+    public void updateActive(String boardId) {
+        Board board = boardRepository.findByBoardId(boardId);
+        board.updateToActive();
+    }
 }

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/ClearedService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/ClearedService.java
@@ -6,6 +6,9 @@ import com.example.KeyboardArenaProject.repository.ClearedRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.OptionalInt;
@@ -25,9 +28,20 @@ public class ClearedService {
     public boolean findIfUserClearDataExists(UserBoardCompositeKey id){
         return clearedRepository.ifClearedById(id);
     }
+
+    public boolean findIfUserDataExists(UserBoardCompositeKey id){
+        return clearedRepository.findByCompositeId(id)!=null;
+    }
     //챌린지 시작 시간 기록
-    public void saveClearStartTime(Cleared cleared){
-        clearedRepository.save(cleared);
+
+    public void saveCleared(String userId, String boardId) {
+        Cleared newCleared = Cleared.builder()
+                .id(userId)
+                .boardId(boardId)
+                .tries(0)
+                .startTime(LocalDateTime.now())
+                .build();
+        clearedRepository.save(newCleared);
     }
 
 
@@ -59,6 +73,15 @@ public class ClearedService {
         return clearedData.updateClearTime();
     }
 
+    public Long getOnlyClearTime(UserBoardCompositeKey compositeKey){
+
+        Cleared curCleared = clearedRepository.findByCompositeId(compositeKey);
+        LocalDateTime startTime = curCleared.getStartTime();
+
+        Duration duration = Duration.between(startTime, LocalDateTime.now());
+        return duration.getSeconds();
+
+    }
     public Cleared findByCompositeId(UserBoardCompositeKey id) {
         return clearedRepository.findByCompositeId(id);
     }

--- a/src/main/resources/static/js/Arena.js
+++ b/src/main/resources/static/js/Arena.js
@@ -7,19 +7,35 @@ if (createButton) {
             headers: {
                 "Content-Type": "application/json"
             },
-            body : JSON.stringify({
+            body: JSON.stringify({
                 title: document.getElementById('title').value,
                 content: document.getElementById('content').value
             }),
-        }).then(() => {
-            alert('등록 완료되었습니다');
-            location.replace("/arenas");
         })
-    })
+            .then(response => response.text()) // 응답을 텍스트로 변환하여 boardId 추출
+            .then(boardId => {
+                if(boardId) { // 성공적으로 boardId를 받았다면
+                    alert('예비 등록이 완료됐습니다!\n'+
+                        '아레나를 게시판에 등록하기 위해서는 본인이 생성한 아레나를 2분 이내로 클리어하여야 합니다\n ' +
+                        '등록에 실패하더라도 [마이페이지->내가 생성한 아레나] 페이지에서 재시도 할 수 있습니다');
+                    console.log(boardId);
+                    window.location.href = `/arena/${boardId}/verify`; // boardId를 사용하여 리다이렉트
+
+                } else {
+                    // boardId가 없거나 잘못된 응답을 받았을 경우
+                    console.log(boardId);
+                    alert('등록 과정에 문제가 발생했습니다. 다시 시도해 주세요.');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('오류가 발생했습니다. 다시 시도해주세요.');
+            });
+    });
 }
 
 
-
+//시작 버튼 작동 로직
 document.addEventListener('DOMContentLoaded', function() {
     const startButton = document.getElementById('start-button');
     const retryButton = document.getElementById('retry-button');
@@ -32,7 +48,7 @@ document.addEventListener('DOMContentLoaded', function() {
         fetch(`/arenas/${boardId}/start`)
             .then(response => response.json()) // 서버로부터 받은 JSON 응답을 파싱
             .then(data => {
-                // 'start-time' 요소에 시작 시간을 표시
+                // start-time 요소에 시작 시간을 표시
                 startTimeElement.innerText = `Start time: ${data.startTime}`;
                 startTimeElement.style.display = 'block';
             })
@@ -52,7 +68,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
-
+//post 작동 로직
 document.addEventListener('DOMContentLoaded', function() {
     const form = document.getElementById('user-typed-content'); // 폼의 ID를 사용합니다.
     const contentInput = document.getElementById('contentInput'); // 사용자가 입력한 텍스트를 가져올 요소의 ID입니다.

--- a/src/main/resources/static/js/Verify.js
+++ b/src/main/resources/static/js/Verify.js
@@ -1,0 +1,75 @@
+
+
+document.addEventListener('DOMContentLoaded', function() {
+    const startVerifyButton = document.getElementById('start-verify-button');
+    const userTypedContent = document.getElementById('user-typed-verify-content');
+    const startTimeElement = document.getElementById('start-time');
+    function sendAsyncRequest() {
+        //콘텐츠 입력창 보이게 함
+        userTypedContent.style.display = 'block';
+        console.log(verifyBoardId);
+        fetch(`/arenas/${verifyBoardId}/verify/start`)
+            .then(response => response.json()) // 서버로부터 받은 JSON 응답을 파싱
+            .then(data => {
+                // 'start-time' 요소에 시작 시간을 표시
+                startTimeElement.innerText = `Start time: ${data.startTime}`;
+                startTimeElement.style.display = 'block';
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                startTimeElement.innerText = '시작 시간을 불러오는데 실패했습니다.\n 새로고침하세요.';
+                startTimeElement.style.display = 'block';
+            });
+    }
+    if (startVerifyButton) {
+        startVerifyButton.addEventListener('click', sendAsyncRequest);
+    }
+});
+
+//verify post 작동 로직
+document.addEventListener('DOMContentLoaded', function() {
+    const submitButton = document.getElementById('arena-verify-btn');
+    const form = document.getElementById('user-typed-verify-content'); // 폼의 ID를 사용합니다.
+    const contentInput = document.getElementById('verifyInput'); // 사용자가 입력한 텍스트를 가져올 요소의 ID
+
+    if (form) {
+        form.addEventListener('submit', function(event) {
+            // 폼의 기본 제출 동작을 방지합니다.
+            event.preventDefault();
+
+            // FormData 객체를 생성하고, 사용자가 입력한 텍스트를 추가합니다.
+            const formData = new FormData();
+            formData.append('userTypedText', verifyInput.value);
+
+            // 서버로 POST 요청을 보냅니다.
+            fetch(`/arena/${verifyBoardId}/verify`, {
+                method: 'POST',
+                body: formData
+            })
+                .then(response => response.text())
+                .then(data => {
+                    alert(data);
+                    if(data ==="아레나 개장 인증 로직 검증 아레나를 120초 내에 클리어하지 못했습니다. 다시 시도해보세요!")
+                        window.location.href = `/arena/${verifyBoardId}/verify`;
+                    else
+                        window.location.href = `/arenas/${verifyBoardId}`;
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    alert('오류가 발생했습니다. 다시 시도해주세요.');
+                });
+        });
+    }
+});
+
+document.addEventListener('copy', function(e) {
+    e.preventDefault(); // 복사 이벤트를 막음
+});
+
+document.addEventListener('cut', function(e) {
+    e.preventDefault(); // 잘라내기 이벤트를 막음
+});
+
+document.addEventListener('paste', function(e) {
+    e.preventDefault(); // 붙여넣기 이벤트를 막음
+});

--- a/src/main/resources/templates/arenaVerify.html
+++ b/src/main/resources/templates/arenaVerify.html
@@ -1,10 +1,62 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Arena 상세보기</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
+    <noscript>
+        <meta http-equiv="refresh" content="/arenas" />
+    </noscript>
+
+    <style>
+        body { /*복붙 금지*/
+            -webkit-user-select: none; /* Safari */
+            -moz-user-select: none; /* Firefox */
+            -ms-user-select: none; /* IE10+/Edge */
+            user-select: none; /* 표준 구문 */
+        }
+    </style>
+
 </head>
 <body>
+
+<!-- 탑 네비게이션 바 -->
+<div class="navbar navbar-expand-lg navbar-light bg-light">
+    <button type="button" onclick="location.href='/mypage'" class="btn btn-primary"th:text="${arena.userTopBarInfo.nickname}">>내 페이지</button>
+    <div class="navbar-text" th:text="'Rank: ' + ${arena.userTopBarInfo.rank}"></div>
+    <div class="navbar-text" th:text="'Points: ' + ${arena.userTopBarInfo.point}"></div>
+
+</div>
+
+<!-- 본문 내용 -->
+<div class="container mt-5">
+    <h2 th:text="${arena.title}"></h2>
+    <h5 th:text="'작성자: ' + ${arena.writer}"></h5>
+    <h6 th:text="'작성일: ' + ${arena.createdDate}"></h6>
+    <h6 th:text="'게시판 랭킹: ' + ${arena.boardRank}"></h6>
+
+    <p th:text="${arena.content}"></p>
+
+    <button type="button" id="start-verify-button" class="btn btn-primary btn-sm">시작</button>
+    <p id="start-time" style="display: none;"></p>
+    <!-- 콘텐트 입력창 -->
+
+
+    <form id="user-typed-verify-content" style="display:none;">
+        <div class="form-group">
+            <label for="verifyInput">내용 입력</label>
+            <textarea class="form-control" id="verifyInput" name="userTypedText" rows="3"></textarea>
+        </div>
+        <button type="submit" id="arena-verify-btn" class="btn btn-primary btn-sm">제출</button>
+    </form>
+
+</div>
+
+<script th:inline="javascript"> var verifyBoardId = [[${arena.boardId}]]; </script>
+<script src="/js/Verify.js"></script>
+<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
#추가한 기능
![image](https://github.com/Garodden/keyboard-arena/assets/44630705/4c5ad207-511c-4748-a8ae-047f84d9620e)
아레나를 업로드 하면
## addNewArena() 제작한 아레나 활성화 전 검증 API 
GET "arena/{boardId}/verify"
![image](https://github.com/Garodden/keyboard-arena/assets/44630705/53026234-fda1-4dce-abcd-d4d2505116a2)

## markArenaVerifyStartTime() 아레나 검증을 위한 시작 시간 기록 비동기 API
GET "arena/{boardId}/verify/start"
![image](https://github.com/Garodden/keyboard-arena/assets/44630705/df913bc0-9ed7-4e64-a4f9-45e96d1ad4ed)

## addNewArena() 유저가 해당 아레나에 참전해서 시간 내에 통과하면 아레나를 활성화시켜주는 API
POST "arena/{boardId}/verify"
![image](https://github.com/Garodden/keyboard-arena/assets/44630705/49a62497-fd3c-4cc0-be72-32961c284c32)
통과하면 "arenas/{boardId}"로 리다이렉팅 해주면서 해당 아레나를 활성화시켜준다