### PR TITLE
Feat: 아이디 찾기/비밀번호 찾기 ui 수정 + 인덱스 페이지에서 검증된 아레나만 조회되도록 수정

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/controller/arena/ArenaController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/arena/ArenaController.java
@@ -58,8 +58,12 @@ public class ArenaController {
             .map(ArenaResponse::new)
             .toList();
 
+        List<String> top3BoardIds = top3ArenaList.stream()
+            .map(Board::getBoardId)
+            .toList();
+
         // 나머지 일반 아레나 생성일자 내림차순
-        List<Board> otherNormalArenaList = arenaService.findNormalArenaOrderByCreatedDate();
+        List<Board> otherNormalArenaList = arenaService.findNormalArenaOrderByCreatedDate(top3BoardIds);
         List<ArenaResponse> otherNormalArenas = otherNormalArenaList.stream()
             .map(ArenaResponse::new)
             .toList();

--- a/src/main/java/com/example/KeyboardArenaProject/controller/freeBoard/FreeBoardController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/freeBoard/FreeBoardController.java
@@ -57,8 +57,12 @@ public class FreeBoardController {
             .map(ArenaResponse::new)
             .toList();
 
+        List<String> top3BoardIds = top3ArenaList.stream()
+            .map(Board::getBoardId)
+            .toList();
+
         // 나머지 일반 아레나 생성일자 내림차순
-        List<Board> otherNormalArenaList = arenaService.findNormalArenaOrderByCreatedDate();
+        List<Board> otherNormalArenaList = arenaService.findNormalArenaOrderByCreatedDate(top3BoardIds);
         List<ArenaResponse> otherNormalArenas = otherNormalArenaList.stream()
             .map(ArenaResponse::new)
             .toList();

--- a/src/main/java/com/example/KeyboardArenaProject/entity/User.java
+++ b/src/main/java/com/example/KeyboardArenaProject/entity/User.java
@@ -28,10 +28,10 @@ import jakarta.persistence.Table;
 public class User implements UserDetails {
 	@Getter
 	@Id
-	@Column(name="id", unique = true, updatable = false)
+	@Column(name="id", updatable = false)
 	private String id;
 
-	@Column(name="user_id", unique = true, nullable = false)
+	@Column(name="user_id", nullable = false)
 	private String userId;
 
 	@Column(name="password", nullable = false)
@@ -46,7 +46,7 @@ public class User implements UserDetails {
 	@Column(name="point")
 	private int point;
 
-	@Column(name="email", unique = true, nullable = false)
+	@Column(name="email", nullable = false)
 	private String email;
 
 	@Column(name="find_pw", nullable = false)

--- a/src/main/java/com/example/KeyboardArenaProject/repository/ArenaRepository.java
+++ b/src/main/java/com/example/KeyboardArenaProject/repository/ArenaRepository.java
@@ -3,6 +3,7 @@ import com.example.KeyboardArenaProject.entity.Board;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,7 +14,7 @@ public interface ArenaRepository extends JpaRepository<Board, String> {
     List<Board> findAllByBoardType(int i);
 
     // top 3 liked normal arena
-    @Query("Select b FROM Board b where b.boardType = 3 order by b.likes desc")
+    @Query("Select b FROM Board b where b.boardType = 3 AND b.ifActive = true order by b.likes desc")
     List<Board> findArenasOrderByLikeDesc(Pageable pageable);
     @Query("SELECT count(b) FROM Board b WHERE b.boardType = 3")
     int findNumberOfArenas();
@@ -21,7 +22,8 @@ public interface ArenaRepository extends JpaRepository<Board, String> {
     Board findByBoardId(String boardId);
 
     // rest of the normal arena
-    List<Board> findByBoardTypeOrderByCreatedDateDesc(int type);
+    @Query("SELECT b FROM Board b where b.boardType = :type AND b.ifActive = true AND b.boardId NOT IN (:topThreeBoardIds) ORDER BY b.createdDate DESC")
+    List<Board> findActiveArenasOrderByCreatedDateDesc(@Param("type") int type, @Param("topThreeBoardIds") List<String> topThreeBoardIds);
 
     void deleteByBoardId(String boardId);
 }

--- a/src/main/java/com/example/KeyboardArenaProject/service/arena/ArenaService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/arena/ArenaService.java
@@ -33,8 +33,8 @@ public class ArenaService {
 
     }
 
-    public List<Board> findNormalArenaOrderByCreatedDate(){
-        return boardRepository.findByBoardTypeOrderByCreatedDateDesc(3);
+    public List<Board> findNormalArenaOrderByCreatedDate(List<String> topThreeBoardIds){
+        return boardRepository.findActiveArenasOrderByCreatedDateDesc(3, topThreeBoardIds);
     }
     @Transactional
     public void saveArena(Board Arena){

--- a/src/main/resources/static/css/user/findId.css
+++ b/src/main/resources/static/css/user/findId.css
@@ -1,3 +1,44 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.container-text {
+    margin-bottom: 5vh;
+}
+
+#findIdForm label {
+    color: #333333;
+}
+
+input[type="email"]
+{
+    width: 100%;
+    padding: 10px;
+    margin: 8px 0;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    box-sizing: border-box;
+}
+
+button {
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+button:hover {
+    box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+
+#send-email-button {
+    width: 100%;
+    padding: 10px;
+    margin: 8px 0;
+    box-sizing: border-box;
+}
+
 #loading {
     display: none;
 }

--- a/src/main/resources/static/css/user/findPw.css
+++ b/src/main/resources/static/css/user/findPw.css
@@ -1,21 +1,23 @@
 #login-button {
     margin-right: 10px;
 }
-.container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
 
-.container-text {
+.container h2 {
     margin-bottom: 5vh;
 }
 
-#findIdForm label {
+.container {
+     display: flex;
+     flex-direction: column;
+     align-items: center;
+ }
+
+#findPwForm label {
     color: #333333;
 }
 
-input[type="email"]
+input,
+select
 {
     width: 100%;
     padding: 10px;
@@ -26,6 +28,8 @@ input[type="email"]
 }
 
 button {
+    width: 100%;
+    padding: 10px;
     border: 1px solid #ccc;
     border-radius: 5px;
     cursor: pointer;
@@ -35,17 +39,6 @@ button:hover {
     box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
 }
 
-#send-email-button {
-    width: 100%;
-    padding: 10px;
-    margin: 8px 0;
-    box-sizing: border-box;
-}
-
-#loading {
-    display: none;
-}
-
-#loading-img {
-    width: 10vw;
+#resetPwResult {
+    margin-top: 20px
 }

--- a/src/main/resources/static/js/user/FindId.js
+++ b/src/main/resources/static/js/user/FindId.js
@@ -1,0 +1,38 @@
+const findIdForm = document.getElementById("findIdForm");
+const loadingDiv = document.querySelector("#loading");
+
+findIdForm.addEventListener("submit", (e) => {
+    e.preventDefault();
+    sendEmail();
+})
+
+function sendEmail() {
+    var formData = new FormData();
+    formData.append("email", document.getElementById("email").value);
+
+    loadingDiv.style.display = "block";
+
+    fetch('/user/find/id', {
+        method: 'POST',
+        body: formData
+    })
+        .then(response => {
+            console.log(response);
+            if (response.ok) {
+                return response;
+            } else {
+                throw new Error('아이디 찾기에 실패했습니다.');
+            }
+        })
+        .then(data => {
+            loadingDiv.style.display = "none";
+            alert("이메일이 발송되었습니다.");
+            // isSearching = false;
+            // location.href='/login' 고민중
+        })
+        .catch(error => {
+            loadingDiv.style.display = "none";
+            console.log('Error: ', error);
+            alert('확인할 수 없는 이메일입니다.')
+        });
+}

--- a/src/main/resources/templates/findId.html
+++ b/src/main/resources/templates/findId.html
@@ -15,6 +15,11 @@
         <div class="title-navbar-container">
             <!--서비스 이름-->
             <h1 class="mb-3" onclick="location.href='/'">Keyboard Arena</h1>
+            <!-- 탑 네비게이션 바 -->
+            <div class="navbar navbar-expand-lg navbar-light bg-light">
+                <button type="button" id="login-button" class="btn btn-primary" onclick="location.href='/login'" >로그인</button>
+                <button type="button" class="btn btn-secondary" onclick="location.href='/signin'">회원가입</button>
+            </div>
         </div>
         <h4 class="mb-3">다른 사람들과 타자 속도를 겨뤄보세요</h4>
     </div>

--- a/src/main/resources/templates/findId.html
+++ b/src/main/resources/templates/findId.html
@@ -3,21 +3,32 @@
 <head>
     <meta charset="UTF-8">
     <title>Keyboard Arena</title>
-<!--    <script src="/js/FindId.js"></script>-->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/common/Header.css" th:href="@{/css/common/Header.css}">
     <link rel="stylesheet" type="text/css" href="/css/user/findId.css" th:href="@{/css/user/findId.css}">
+    <script defer src="/js/user/FindId.js"></script>
 </head>
 <body>
 <header>
-    <h1>Keyboard Arena</h1>
+    <div class="p-5 mb-5 text-center</> bg-light">
+        <!-- flex 적용을 위한 컨테이너 -->
+        <div class="title-navbar-container">
+            <!--서비스 이름-->
+            <h1 class="mb-3" onclick="location.href='/'">Keyboard Arena</h1>
+        </div>
+        <h4 class="mb-3">다른 사람들과 타자 속도를 겨뤄보세요</h4>
+    </div>
 </header>
 <main>
-    <div>
-        <h2>아이디 찾기</h2>
-        회원가입 시 입력하신 이메일로 아이디를 보내드립니다.<br>
+    <div class="container">
+        <h2>아이디 찾기</h2><br>
+        <div class="container-text">
+            회원가입 시 입력하신 이메일로 아이디를 보내드립니다.
+        </div>
         <form id="findIdForm" action="/user/find/id" method="POST">
             <label for="email">이메일 입력</label>
-            <input type="email" id="email" name="email" required>
-            <button type="submit">이메일 발송</button>
+            <input type="email" id="email" name="email" placeholder="userid@company.com" required>
+            <button id="send-email-button" type="submit">이메일 발송</button>
         </form><br>
         <div id="loading">
             아이디를 찾는 중입니다.<br>
@@ -26,43 +37,7 @@
     </div>
 </main>
 <script>
-    const findIdForm = document.getElementById("findIdForm");
-    const loadingDiv = document.querySelector("#loading");
 
-    findIdForm.addEventListener("submit", (e) => {
-        e.preventDefault();
-        sendEmail();
-    })
-
-    function sendEmail() {
-        var formData = new FormData();
-        formData.append("email", document.getElementById("email").value);
-
-        loadingDiv.style.display = "block";
-
-        fetch('/user/find/id', {
-            method: 'POST',
-            body: formData
-        })
-            .then(response => {
-                if (response.ok) {
-                    return response;
-                } else {
-                    throw new Error('아이디 찾기에 실패했습니다.');
-                }
-            })
-            .then(data => {
-                loadingDiv.style.display = "none";
-                alert("이메일이 발송되었습니다.");
-                // isSearching = false;
-                // location.href='/login' 고민중
-            })
-            .catch(error => {
-                loadingDiv.style.display = "none";
-                console.log('Error: ', error);
-                alert('확인할 수 없는 이메일입니다.')
-            });
-    }
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/findPw.html
+++ b/src/main/resources/templates/findPw.html
@@ -3,27 +3,46 @@
 <head>
     <meta charset="UTF-8">
     <title>Keyboard Arena</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/common/Header.css" th:href="@{/css/common/Header.css}">
+    <link rel="stylesheet" type="text/css" href="/css/user/findPw.css" th:href="@{/css/user/findPw.css}">
     <script defer src="/js/user/FindPw.js"></script>
 </head>
 <body>
 <header>
-    <h1>Keyboard Arena</h1>
+    <div class="p-5 mb-5 text-center</> bg-light">
+        <!-- flex 적용을 위한 컨테이너 -->
+        <div class="title-navbar-container">
+            <!--서비스 이름-->
+            <h1 class="mb-3" onclick="location.href='/'">Keyboard Arena</h1>
+            <!-- 탑 네비게이션 바 -->
+            <div class="navbar navbar-expand-lg navbar-light bg-light">
+                <button type="button" id="login-button" class="btn btn-primary" onclick="location.href='/login'" >로그인</button>
+                <button type="button" class="btn btn-secondary" onclick="location.href='/signin'">회원가입</button>
+            </div>
+        </div>
+        <h4 class="mb-3">다른 사람들과 타자 속도를 겨뤄보세요</h4>
+    </div>
 </header>
 <main>
-    <div>
+    <div class="container">
         <h2>비밀번호 찾기</h2>
+
         <form id="findPwForm">
-            회원 아이디와 함께 회원가입시 등록한 질문과 답변을 입력하세요. 입력한 정보가 일치할 경우 비밀번호를 초기화합니다.<br><br>
-            <label for="userId">아이디</label><br><br>
+            <div id="container-text">
+                회원 아이디와 함께 회원가입시 등록한 질문과 답변을 입력하세요. <br>
+                입력한 정보가 일치할 경우 비밀번호를 초기화합니다.
+            </div><br>
+            <label for="userId">아이디</label><br>
             <input id="userId" name="userId" required><br><br>
-            <label for="findPwQuestion">비밀번호 확인 질문</label><br><br>
+            <label for="findPwQuestion">비밀번호 확인 질문</label><br>
             <select name="questions" id="findPwQuestion" required>
                 <option value="place">기억에 남는 추억의 장소는?</option>
                 <option value="treasure">자신의 보물 제1호는?</option>
                 <option value="elementary">자신의 출신 초등학교는?</option>
             </select><br><br>
-            <label for="findPwAnswer">비밀번호 확인 답변</label><br><br>
-            <input id="findPwAnswer" name="findPwAnswer" required>
+            <label for="findPwAnswer">비밀번호 확인 답변</label><br>
+            <input id="findPwAnswer" name="findPwAnswer" required><br>
             <button id="resetPwButton" type="submit">확인</button>
         </form>
         <div id="resetPwResult"></div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/index.css" th:href="@{/css/index.css}">
     <script defer src="/js/common/LogoutBtn.js"></script>
-    <script src="/js/arena/Arena.js"></script>
+    <script defer src="/js/arena/Arena.js"></script>
 </head>
 <body>
 <header>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #47 

## 📝 구현 사항
<!-- 과제에 대한 설명을 적어주세요 -->
1. 아이디 찾기/비밀번호 찾기 ui 수정
2. 인덱스 페이지에서 전체 아레나 조회시 검증된 아레나(if_active 가 true)만 조회되도록 수정
+ 좋아요 상위 3개 일반 아레나를 제외한 나머지 일반 아레나를 작성일자 기준 내림차순 조회하도록 수정

- ✔ 아이디 찾기 화면: `findId.html` 
- ✔ 비밀번호 찾기(초기화) 화면: `findPw.html` 

## 캡쳐
![image](https://github.com/Garodden/keyboard-arena/assets/82032418/80e03360-5e59-483f-bca3-745675d49496)
![image](https://github.com/Garodden/keyboard-arena/assets/82032418/b26e0a87-d8a7-49c5-a2cc-25f9249bf4f9)


## TODO
- []

