### PR TITLE
Feat: (마이페이지)좋아요 누른 게시물 전체 조회 + 작성한 게시물 전체 조회 ui 수정

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.example.KeyboardArenaProject.dto.mypage.MyArenaResponse;
 import com.example.KeyboardArenaProject.dto.mypage.MyCommentedBoardsResponse;
+import com.example.KeyboardArenaProject.dto.mypage.MyLikedBoardsResponse;
 import com.example.KeyboardArenaProject.dto.user.ChangePwRequest;
 import com.example.KeyboardArenaProject.dto.user.DeleteUserRequest;
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
@@ -124,11 +125,7 @@ public class MyPageController {
                 log.info("MyPageController - getLikedBoards: 좋아요 boardId는 {}, id는 {}",
                     like.getCompositeId().getBoardId(), like.getCompositeId().getId());
             }
-            List<Board> likedBoards = myPageService.getMyLikedBoards(likes);
-            for (Board board : likedBoards) {
-                log.info("MyPageController - getLikedBoards: 좋아요 누른 게시글 boardId는 {}, id는 {}", board.getBoardId(),
-                    board.getId());
-            }
+            List<MyLikedBoardsResponse> likedBoards = myPageService.getMyLikedBoards(likes);
             model.addAttribute("likedBoards", likedBoards);
             return "likedboards";
         } catch (MyPageService.MyLikeNotFoundExcpetion e) {

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -116,6 +116,8 @@ public class MyPageController {
     public String getLikedBoards(Model model) {
         User user = userService.getCurrentUserInfo();
         String userId = user.getUserId();
+        model.addAttribute("userTopBarInfo", UserTopBarInfoUtil.getUserTopBarInfo());
+
         try {
             List<Like> likes = myPageService.getMyLikes(userId);
             for (Like like : likes) {

--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/MyPageController.java
@@ -116,11 +116,11 @@ public class MyPageController {
     @GetMapping("/mypage/boards/liked")
     public String getLikedBoards(Model model) {
         User user = userService.getCurrentUserInfo();
-        String userId = user.getUserId();
+        String id = user.getId();
         model.addAttribute("userTopBarInfo", UserTopBarInfoUtil.getUserTopBarInfo());
 
         try {
-            List<Like> likes = myPageService.getMyLikes(userId);
+            List<Like> likes = myPageService.getMyLikes(id);
             for (Like like : likes) {
                 log.info("MyPageController - getLikedBoards: 좋아요 boardId는 {}, id는 {}",
                     like.getCompositeId().getBoardId(), like.getCompositeId().getId());

--- a/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyLikedBoardsResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyLikedBoardsResponse.java
@@ -1,0 +1,34 @@
+package com.example.KeyboardArenaProject.dto.mypage;
+
+import java.time.LocalDateTime;
+
+import com.example.KeyboardArenaProject.entity.Board;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyLikedBoardsResponse {
+	String boardId;
+	int boardType;
+	String title;
+	String author;
+	LocalDateTime createdDate;
+	int likes;
+
+	@Builder
+	MyLikedBoardsResponse(Board board, String author) {
+		this.boardId = board.getBoardId();
+		this.boardType = board.getBoardType();
+		this.title = board.getTitle();
+		this.author = author;
+		this.createdDate = board.getCreatedDate();
+		this.likes = board.getLikes();
+	}
+}

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
@@ -1,6 +1,7 @@
 package com.example.KeyboardArenaProject.service.user;
 import com.example.KeyboardArenaProject.dto.mypage.MyArenaResponse;
 import com.example.KeyboardArenaProject.dto.mypage.MyCommentedBoardsResponse;
+import com.example.KeyboardArenaProject.dto.mypage.MyLikedBoardsResponse;
 import com.example.KeyboardArenaProject.dto.user.MyPageInformation;
 import com.example.KeyboardArenaProject.entity.Board;
 import com.example.KeyboardArenaProject.entity.Cleared;
@@ -101,15 +102,26 @@ public class MyPageService {
         return likeRepository.findByCompositeId_Id(userId);
     }
 
-    public List<Board> getMyLikedBoards(List<Like> likes) {
+    public List<MyLikedBoardsResponse> getMyLikedBoards(List<Like> likes) {
         List<String> boardIds = likes.stream()
             .map(like -> like.getCompositeId().getBoardId())
             .collect(Collectors.toList());
+
         List<Board> myLikedBoards = myPageRepository.findAllByBoardIdInOrderByCreatedDateDesc(boardIds);
-        for (Board likedBoard : myLikedBoards) {
-            log.info("MyPageService - getMyLikedBoards: 작성일자 내림차순으로 조회한 좋아요 누른 게시물의 작성일자 : {}", likedBoard.getCreatedDate());
-        }
-        return myLikedBoards;
+
+        List<MyLikedBoardsResponse> myLikedBoardResponses = myLikedBoards
+            .stream()
+            .map(board -> {
+                String author = userService.getNickNameById(board.getId());
+                return MyLikedBoardsResponse.builder()
+                    .board(board)
+                    .author(author)
+                    .build();
+
+            })
+            .toList();
+
+        return myLikedBoardResponses;
     }
 
     public List<MyArenaResponse> getMyArenaDetails(String id) {

--- a/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
+++ b/src/main/java/com/example/KeyboardArenaProject/service/user/MyPageService.java
@@ -94,12 +94,12 @@ public class MyPageService {
         return myBoards;
     }
 
-    public List<Like> getMyLikes(String userId) {
-        List<Like> myLikes = likeRepository.findByCompositeId_Id(userId);
+    public List<Like> getMyLikes(String id) {
+        List<Like> myLikes = likeRepository.findByCompositeId_Id(id);
         if(myLikes.isEmpty()) {
             throw new MyLikeNotFoundExcpetion("좋아요를 누른 게시글이 없습니다");
         }
-        return likeRepository.findByCompositeId_Id(userId);
+        return myLikes;
     }
 
     public List<MyLikedBoardsResponse> getMyLikedBoards(List<Like> likes) {

--- a/src/main/resources/static/css/mypage/MyPageBoards.css
+++ b/src/main/resources/static/css/mypage/MyPageBoards.css
@@ -52,3 +52,10 @@ tbody tr:hover {
 .clickable-row {
     cursor: pointer;
 }
+
+/* 주간 아레나 prefix */
+.weekly-prefix {
+    font-size: 0.75rem;
+    color: #ff4162;
+    font-weight: bold;
+}

--- a/src/main/resources/templates/commentBoards.html
+++ b/src/main/resources/templates/commentBoards.html
@@ -52,7 +52,7 @@
             <thead>
             <tr>
                 <th style="white-space: nowrap;">번호</th>
-                <th style="white-space: nowrap; color: #676767">유형</th>
+                <th style="white-space: nowrap; color: #1f6dff">유형</th>
                 <th style="white-space: nowrap; color: #1f6dff">제목</th>
                 <th style="white-space: nowrap;">작성자</th>
                 <th style="white-space: nowrap;">작성일</th>

--- a/src/main/resources/templates/commentBoards.html
+++ b/src/main/resources/templates/commentBoards.html
@@ -85,8 +85,8 @@
                 <td>
                     <span th:switch="${board.boardType}" style="color: #1f6dff">
                         <span th:case="1" style="color: #414141">자유게시판</span>
-                        <span th:case="2" style="color: #1f6dff">아레나</span>
-                        <span th:case="3" style="color: #1f6dff">아레나</span>
+                        <span th:case="2" style="color: #1f6dff">주간 랭크전</span>
+                        <span th:case="3" style="color: #1f6dff">일반 아레나</span>
                         <span th:case="*" th:text="'Unknown'"></span>
                     </span>
                 </td>
@@ -103,7 +103,7 @@
                                     </span><br>
                                 <span th:text="${comment.content}" ></span>
                                 <hr th:if="${commentIndex.index != #lists.size(board.commentResponses) - 1}"
-                                    style="border: 1px #d3d3d3; margin-top: 0.5rem; margin-bottom: 0.5rem;">
+                                    style="border-color: #d3d3d3; margin-top: 0.5rem; margin-bottom: 0.5rem;">
                             </div>
                         </li>
                     </ul>

--- a/src/main/resources/templates/likedBoards.html
+++ b/src/main/resources/templates/likedBoards.html
@@ -3,35 +3,103 @@
 <head>
     <meta charset="UTF-8">
     <title>Keyboard Arena</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/common/Header.css" th:href="@{/css/common/Header.css}">
     <link rel="stylesheet" type="text/css" href="/css/mypage/MyPageBoards.css" th:href="@{/css/mypage/MyPageBoards.css}">
+    <link rel="stylesheet" type="text/css" href="/css/mypage/MypageMenu.css" th:href="@{/css/mypage/MypageMenu.css}">
     <script defer src="/js/mypage/MyPageGetBoardDetails.js"></script>
+    <script defer src="/js/common/LogoutBtn.js"></script>
 </head>
 <body>
-<h1>Keyboard Arena</h1>
-<h2>My Page</h2>
-<h3>좋아요 누른 게시물</h3>
-<div th:unless="${likedBoards}">
-    <p th:text="${errorMessage}"></p>
-</div>
-<table th:if="${likedBoards}">
-    <thead>
-        <tr>
-            <th>번호</th>
-            <th>제목</th>
-            <th>작성자</th>
-            <th>작성일</th>
-            <th>좋아요</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr th:each="board, index : ${likedBoards}" class="clickable-row" th:attr="board-id=${board.getBoardId()}, board-type=${board.boardType}">
-            <td th:text="${index.index + 1}"></td>
-            <td th:text="${board.title}"></td>
-            <td th:text="${board.id}"></td>
-            <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
-            <td th:text="${board.likes}"></td>
-        </tr>
-    </tbody>
-</table>
+<header>
+    <!-- 공통 헤더 start ======> -->
+    <div class="p-5 mb-5 text-center</> bg-light">
+        <!-- flex 적용을 위한 컨테이너 -->
+        <div class="title-navbar-container">
+            <!--서비스 이름-->
+            <h1 class="mb-3" onclick="location.href='/'">Keyboard Arena</h1>
+            <!-- 탑 네비게이션 바 -->
+            <div class="navbar navbar-expand-lg navbar-light bg-light">
+                <div class="navbar-text" id="navbar-nickname" th:text="${userTopBarInfo.nickname} + '&nbsp;&nbsp;'"></div>
+                <div class="navbar-text" th:text="'Rank: ' + ${userTopBarInfo.rank} + '&nbsp;&nbsp;'"></div>
+                <div class="navbar-text" th:text="'Points: ' + ${userTopBarInfo.point} + '&nbsp;&nbsp;'"></div>
+                <button type="button" class="btn btn-primary" onclick="location.href='/mypage'" >마이페이지</button>
+                <button type="button" class="btn btn-secondary" id="logoutButton">로그아웃</button>
+            </div>
+        </div>
+        <h4 class="mb-3">다른 사람들과 타자 속도를 겨뤄보세요</h4>
+    </div>
+    <!-- ======> 공통 헤더 end -->
+</header>
+<main>
+    <!-- mypage 공통 메뉴 html start ======> -->
+    <div class="list-group-container">
+        <div class="list-group">
+            <a href="/mypage/arenas" class="list-group-item list-group-item-action">내가 참전한 아레나</a>
+            <a href="/mypage/boards/commented" class="list-group-item list-group-item-action">내가 댓글 단 게시물</a>
+            <a href="/mypage/boards" class="list-group-item list-group-item-action">내가 쓴 게시물</a>
+            <a href="/mypage/boards/liked" class="list-group-item list-group-item-action"  style="border-bottom: 1px solid #919191;">좋아요 누른 게시물</a>
+        </div>
+    </div>
+    <!-- ======> mypage 공통 메뉴 html end -->
+    <div class="main-content">
+        <div class="main-content-subtitle">
+            <h2>My Page</h2>
+            <div class="main-content-subtitle">
+                좋아요 누른 게시물
+            </div>
+        </div>
+        <table th:unless="${likedBoards}">
+            <thead>
+                <tr>
+                    <th style="white-space: nowrap;">번호</th>
+                    <th style="white-space: nowrap; color: #1f6dff">유형</th>
+                    <th style="white-space: nowrap; color: #1f6dff">제목</th>
+                    <th style="white-space: nowrap;">작성자</th>
+                    <th style="white-space: nowrap;">작성일</th>
+                    <th style="white-space: nowrap; color: #1f6dff" >좋아요</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan="6" th:text="${errorMessage}"></td>
+                </tr>
+            </tbody>
+        </table>
+        <table th:if="${likedBoards}">
+            <thead>
+            <tr>
+                <th style="white-space: nowrap;">번호</th>
+                <th style="white-space: nowrap; color: #1f6dff">유형</th>
+                <th style="white-space: nowrap; color: #1f6dff">제목</th>
+                <th style="white-space: nowrap;">작성자</th>
+                <th style="white-space: nowrap;">작성일</th>
+                <th style="white-space: nowrap; color: #1f6dff" >좋아요</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="board, index : ${likedBoards}" class="clickable-row" th:attr="board-id=${board.getBoardId()}, board-type=${board.boardType}">
+                <td th:text="${index.index + 1}"></td>
+                <td>
+                    <span th:switch="${board.boardType}" style="color: #1f6dff">
+                        <span th:case="1" style="color: #414141">자유게시판</span>
+                        <span th:case="2" style="color: #1f6dff">주간 랭크전</span>
+                        <span th:case="3" style="color: #1f6dff">일반 아레나</span>
+                        <span th:case="*" th:text="'Unknown'"></span>
+                    </span>
+                </td>
+                <td th:text="${board.title}"></td>
+                <td th:text="${board.id}"></td>
+                <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
+                <td th:text="${board.likes}"></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+
+
+</main>
+
 </body>
 </html>

--- a/src/main/resources/templates/likedBoards.html
+++ b/src/main/resources/templates/likedBoards.html
@@ -89,7 +89,7 @@
                     </span>
                 </td>
                 <td th:text="${board.title}"></td>
-                <td th:text="${board.id}"></td>
+                <td th:text="${board.author}"></td>
                 <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
                 <td th:text="${board.likes}"></td>
             </tr>

--- a/src/main/resources/templates/myArenas.html
+++ b/src/main/resources/templates/myArenas.html
@@ -84,7 +84,10 @@
             <tbody th:if="${not #lists.isEmpty(myArenas)}">
                 <tr th:each="arena, index : ${myArenas}" class="clickable-row" th:attr="board-id=${arena.getBoardId()}, board-type=${arena.boardType}">
                     <td th:text="${index.index + 1}"></td>
-                    <td th:text="${arena.title}"></td>
+                    <td>
+                        <span th:if="${arena.boardType == 2}" class="weekly-prefix">(주간) </span>
+                        <span th:text="${arena.title}"></span>
+                    </td>
                     <td th:text="${arena.boardRank}"></td>
                     <td th:text="${#temporals.format(arena.createdDate, 'yyyy.MM.dd')}"></td>
                     <td th:text="${arena.participates}"></td>

--- a/src/main/resources/templates/myboards.html
+++ b/src/main/resources/templates/myboards.html
@@ -3,33 +3,126 @@
 <head>
     <meta charset="UTF-8">
     <title>Keyboard Arena</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/common/Header.css" th:href="@{/css/common/Header.css}">
     <link rel="stylesheet" type="text/css" href="/css/mypage/MyPageBoards.css" th:href="@{/css/mypage/MyPageBoards.css}">
+    <link rel="stylesheet" type="text/css" href="/css/mypage/MypageMenu.css" th:href="@{/css/mypage/MypageMenu.css}">
     <script defer src="/js/mypage/MyPageGetBoardDetails.js"></script>
+    <script defer src="/js/common/LogoutBtn.js"></script>
 </head>
 <body>
-<h1>Keyboard Arena</h1>
-<h2>My Page</h2>
-<h3>내가 쓴 게시물</h3>
-<div th:unless="${myBoards}">
-    <p th:text="${errorMessage}"></p>
-</div>
-<table th:if="${myBoards}">
-    <thead>
-        <tr>
-            <th>번호</th>
-            <th>제목</th>
-            <th>작성일</th>
-            <th>좋아요</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr th:each="board, index : ${myBoards}" class="clickable-row" th:attr="board-id=${board.getBoardId()}, board-type=${board.boardType}">
-            <td th:text="${index.index + 1}"></td>
-            <td th:text="${board.title}"></td>
-            <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
-            <td th:text="${board.likes}"></td>
-        </tr>
-    </tbody>
-</table>
+<header>
+    <!-- 공통 헤더 start ======> -->
+    <div class="p-5 mb-5 text-center</> bg-light">
+        <!-- flex 적용을 위한 컨테이너 -->
+        <div class="title-navbar-container">
+            <!--서비스 이름-->
+            <h1 class="mb-3" onclick="location.href='/'">Keyboard Arena</h1>
+            <!-- 탑 네비게이션 바 -->
+            <div class="navbar navbar-expand-lg navbar-light bg-light">
+                <div class="navbar-text" id="navbar-nickname" th:text="${userTopBarInfo.nickname} + '&nbsp;&nbsp;'"></div>
+                <div class="navbar-text" th:text="'Rank: ' + ${userTopBarInfo.rank} + '&nbsp;&nbsp;'"></div>
+                <div class="navbar-text" th:text="'Points: ' + ${userTopBarInfo.point} + '&nbsp;&nbsp;'"></div>
+                <button type="button" class="btn btn-primary" onclick="location.href='/mypage'" >마이페이지</button>
+                <button type="button" class="btn btn-secondary" id="logoutButton">로그아웃</button>
+            </div>
+        </div>
+        <h4 class="mb-3">다른 사람들과 타자 속도를 겨뤄보세요</h4>
+    </div>
+    <!-- ======> 공통 헤더 end -->
+</header>
+<main>
+    <!-- mypage 공통 메뉴 html start ======> -->
+    <div class="list-group-container">
+        <div class="list-group">
+            <a href="/mypage/arenas" class="list-group-item list-group-item-action">내가 참전한 아레나</a>
+            <a href="/mypage/boards/commented" class="list-group-item list-group-item-action">내가 댓글 단 게시물</a>
+            <a href="/mypage/boards" class="list-group-item list-group-item-action" style="border-bottom: 1px solid #919191;">내가 쓴 게시물</a>
+            <a href="/mypage/boards/liked" class="list-group-item list-group-item-action"  >좋아요 누른 게시물</a>
+        </div>
+    </div>
+    <!-- ======> mypage 공통 메뉴 html end -->
+    <div class="main-content">
+        <h2>My Page</h2>
+        <div class="main-content-subtitle">
+            내가 쓴 게시물
+        </div>
+        <table th:unless="${myBoards}">
+            <thead>
+            <tr>
+                <th style="white-space: nowrap;">번호</th>
+                <th style="white-space: nowrap; color: #1f6dff">유형</th>
+                <th style="white-space: nowrap; color: #1f6dff">제목</th>
+                <th style="white-space: nowrap;">작성일</th>
+                <th style="white-space: nowrap;">좋아요</th>
+                <th style="white-space: nowrap; color: #1f6dff" >수정하러 가기</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td colspan="6" th:text="${errorMessage}"></td>
+            </tr>
+            </tbody>
+        </table>
+        <table th:if="${myBoards}">
+            <thead>
+            <tr>
+                <th style="white-space: nowrap;">번호</th>
+                <th style="white-space: nowrap; color: #1f6dff">유형</th>
+                <th style="white-space: nowrap; color: #1f6dff">제목</th>
+                <th style="white-space: nowrap;">작성일</th>
+                <th style="white-space: nowrap;">좋아요</th>
+                <th style="white-space: nowrap; color: #1f6dff" >수정하러 가기</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="board, index : ${myBoards}" class="clickable-row" th:attr="board-id=${board.getBoardId()}, board-type=${board.boardType}">
+                <td th:text="${index.index + 1}"></td>
+                <td>
+                    <span th:switch="${board.boardType}" style="color: #1f6dff">
+                        <span th:case="1" style="color: #414141">자유게시판</span>
+<!--                        <span th:case="2" style="color: #1f6dff">주간 랭크전</span>-->
+                        <span th:case="3" style="color: #1f6dff">일반 아레나</span>
+                        <span th:case="*" th:text="'Unknown'"></span>
+                    </span>
+                </td>
+                <td th:text="${board.title}"></td>
+                <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
+                <td th:text="${board.likes}"></td>
+                <td>
+                    <a th:href="@{'/board/' + ${board.getBoardId()} + '/update'}">
+                        수정
+                    </a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+
+</main>
+
+<!---->
+<!--<div th:unless="${myBoards}">-->
+<!--    <p th:text="${errorMessage}"></p>-->
+<!--</div>-->
+<!--<table th:if="${myBoards}">-->
+<!--    <thead>-->
+<!--        <tr>-->
+<!--            <th>번호</th>-->
+<!--            <th>제목</th>-->
+<!--            <th>작성일</th>-->
+<!--            <th>좋아요</th>-->
+<!--        </tr>-->
+<!--    </thead>-->
+<!--    <tbody>-->
+<!--        <tr th:each="board, index : ${myBoards}" class="clickable-row" th:attr="board-id=${board.getBoardId()}, board-type=${board.boardType}">-->
+<!--            <td th:text="${index.index + 1}"></td>-->
+<!--            <td th:text="${board.title}"></td>-->
+<!--            <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>-->
+<!--            <td th:text="${board.likes}"></td>-->
+<!--        </tr>-->
+<!--    </tbody>-->
+<!--</table>-->
 </body>
 </html>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #50 

## 📝 구현 사항
<!-- 과제에 대한 설명을 적어주세요 -->
- 댓글 단 게시물 전체를 조회합니다
- ✔ 마이페이지 - 작성한 게시물 전체 조회: `~/mypage/boards` 
  1. "유형" 칼럼 추가 -> `일반 아레나 / 자유 게시판` 분류 확인 가능
  2. "수정하러가기" 칼럼 추가 -> 아레나 수정 / 자유게시판 게시글 수정 페이지로 연결
  ![image](https://github.com/Garodden/keyboard-arena/assets/82032418/d20d6f46-cd3b-46e0-b939-e7c334a09f31)

- ✔ 마이페이지 - 댓글 쓴 게시글 전체 조회: `~/mypage/boards/liked`
    1. "유형" 칼럼 추가 -> `주간 랭크전 / 일반 아레나 / 자유 게시판` 분류 확인 가능
![image](https://github.com/Garodden/keyboard-arena/assets/82032418/7596400d-f375-4cf5-99b2-8d7e48fd001a)
