### PR TITLE
Fix: 마이페이지 작성한 글 전체 조회 ui 수정, 회원가입 api 예외처리 추가

### DIFF
--- a/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
+++ b/src/main/java/com/example/KeyboardArenaProject/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package com.example.KeyboardArenaProject.controller.user;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -45,7 +46,7 @@ public class UserController {
 			User user = userService.save(request);
 			return ResponseEntity.status(HttpStatus.CREATED)
 				.body(user.toResponse());
-		} catch(IllegalArgumentException ex) {
+		} catch(IllegalArgumentException | DataIntegrityViolationException ex) {
 			return ResponseEntity.badRequest().body(ex.getMessage());
 		}
 

--- a/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyArenaResponse.java
+++ b/src/main/java/com/example/KeyboardArenaProject/dto/mypage/MyArenaResponse.java
@@ -17,6 +17,7 @@ public class MyArenaResponse {
 	int participates;
 	int comments;
 	int likes;
+	Boolean ifActive;
 	double percentage;
 
 	@Builder
@@ -29,6 +30,7 @@ public class MyArenaResponse {
 		this.participates = participates;
 		this.comments =board.getComments();
 		this.likes = board.getLikes();
+		this.ifActive = board.getIfActive();
 		this.percentage = percentage;
 	}
 }

--- a/src/main/java/com/example/KeyboardArenaProject/entity/User.java
+++ b/src/main/java/com/example/KeyboardArenaProject/entity/User.java
@@ -25,7 +25,7 @@ import com.example.KeyboardArenaProject.utils.user.GenerateIdUtils;
 public class User implements UserDetails {
 	@Getter
 	@Id
-	@Column(name="id", updatable = false)
+	@Column(name="id", updatable = false, unique = true)
 	private String id;
 
 	@Column(name="user_id", nullable = false)

--- a/src/main/resources/templates/myboards.html
+++ b/src/main/resources/templates/myboards.html
@@ -90,9 +90,7 @@
                 <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
                 <td th:text="${board.likes}"></td>
                 <td><a th:href="@{'/board/' + ${board.getBoardId()} + '/update'}"
-                       th:unless="${
-                       userTopBarInfo.userId.length() >= 4 &&
-                       userTopBarInfo.userId.substring(userTopBarInfo.userId.length()-4,userTopBarInfo.userId.length())}=='(탈퇴)'">
+                       th:unless="${userTopBarInfo.userId.contains('(탈퇴)')}">
                     수정
                 </a>
 

--- a/src/main/resources/templates/myboards.html
+++ b/src/main/resources/templates/myboards.html
@@ -86,7 +86,11 @@
                         <span th:case="*" th:text="'Unknown'"></span>
                     </span>
                 </td>
-                <td th:text="${board.title}"></td>
+                <td>
+                    <span th:if="${board.boardType == 3 && board.ifActive == false}" style="font-weight: bold; color: #ff3459">(검증 필요)</span>
+                    <span th:if="${board.boardType == 3 &&  board.ifActive == true}" style="color: #1f6dff">(등록 완료)</span>
+                    <span th:text="${board.title}"></span>
+                </td>
                 <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
                 <td th:text="${board.likes}"></td>
                 <td><a th:href="@{'/board/' + ${board.getBoardId()} + '/update'}"

--- a/src/main/resources/templates/myboards.html
+++ b/src/main/resources/templates/myboards.html
@@ -89,10 +89,13 @@
                 <td th:text="${board.title}"></td>
                 <td th:text="${#temporals.format(board.createdDate, 'yyyy.MM.dd')}"></td>
                 <td th:text="${board.likes}"></td>
-                <td>
-                    <a th:href="@{'/board/' + ${board.getBoardId()} + '/update'}" th:unless="${userTopBarInfo.userId.substring(userTopBarInfo.userId.length()-4,userTopBarInfo.userId.length())}=='(탈퇴)'">
-                        수정
-                    </a>
+                <td><a th:href="@{'/board/' + ${board.getBoardId()} + '/update'}"
+                       th:unless="${
+                       userTopBarInfo.userId.length() >= 4 &&
+                       userTopBarInfo.userId.substring(userTopBarInfo.userId.length()-4,userTopBarInfo.userId.length())}=='(탈퇴)'">
+                    수정
+                </a>
+
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
## 관련 이슈
- #1 
- #50 

## 구현사항
- 마이페이지에서 작성한 글 전체를 조회할 때, 자격 검증 여부에 따라 제목을 다르게 표기합니다
  - 자격 검증을 거치지 않은 아레나: `(검증 필요)` 표기
  - 자격 검증을 거친 아레나: `(등록 완료)` 표기
 
![image](https://github.com/Garodden/keyboard-arena/assets/82032418/a7a98cd0-f736-436f-9399-eb9d01ba3d9c)

- 동일한 key로 유저가 생성될 경우에 대한 회원가입 예외처리 추가
  - 가입일시에 따라 id(key)가 생성되다 보니, 동일한 일시에 가입하여 id가 중복될 경우에 대한 `DataIntegrityViolationException` 처리를 추가합니다